### PR TITLE
chore: ignora pasta local .netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ sw.*
 .env.local
 .env.production
 .env.development
+
+# Local Netlify folder
+.netlify


### PR DESCRIPTION
## O quê

Adiciona `.netlify` ao `.gitignore`.

## Por quê

A pasta foi criada pelo `netlify link` ao vincular o projeto à CLI do Netlify (usada para diagnosticar o deploy). É estado local e não deve ir pro versionamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)