### PR TITLE
docs: atualiza contato do README para o LinkedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Quer adicionar um grupo ou corrigir uma informação? Use o formulário de contr
 ## Desenvolvedor :computer:
 
 - **Adams Alves** — [github.com/adamsalves](https://github.com/adamsalves)
-- Contato: contato@adamsalves.com.br
+- Contato: [linkedin.com/in/adams-alves](https://www.linkedin.com/in/adams-alves/)
 
 ## Apoie no Ko-fi :raised_hands: :coffee:
 


### PR DESCRIPTION
Troca o contato do desenvolvedor no README (e-mail → LinkedIn).

`contato@adamsalves.com.br` → [linkedin.com/in/adams-alves](https://www.linkedin.com/in/adams-alves/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)