### PR TITLE
fix(mobile-sheet): melhora gesto de drag e baixa snap inicial para peek

### DIFF
--- a/components/explore/MobileSheet.vue
+++ b/components/explore/MobileSheet.vue
@@ -97,7 +97,7 @@ const PEEK_OFFSET = 132
 
 const sheetRef = ref<HTMLElement | null>(null)
 const bodyRef = ref<HTMLElement | null>(null)
-const snap = ref<Snap>('half')
+const snap = ref<Snap>('peek')
 const dragging = ref(false)
 
 let startY = 0
@@ -125,8 +125,14 @@ function onPointerDown(event: PointerEvent) {
   moved = false
   startY = event.clientY
   startTop = sheet.getBoundingClientRect().top
+  // garante que o stream de pointer events continue chegando mesmo se o dedo
+  // sair do handle durante o arraste
+  if (event.target instanceof Element) {
+    event.target.setPointerCapture(event.pointerId)
+  }
   window.addEventListener('pointermove', onPointerMove, { passive: false })
   window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerUp)
 }
 
 function onPointerMove(event: PointerEvent) {
@@ -150,6 +156,7 @@ function onPointerMove(event: PointerEvent) {
 function onPointerUp() {
   window.removeEventListener('pointermove', onPointerMove)
   window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
   dragging.value = false
 
   const sheet = sheetRef.value
@@ -194,6 +201,7 @@ watch(
 onBeforeUnmount(() => {
   window.removeEventListener('pointermove', onPointerMove)
   window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
 })
 </script>
 
@@ -238,13 +246,25 @@ onBeforeUnmount(() => {
   }
 
   .sheet__grab {
+    position: relative;
+    width: 100%;
+    height: 28px;
+    flex: 0 0 auto;
+    cursor: grab;
+    touch-action: none;
+  }
+
+  /* barrinha visual (48×5) centralizada — a hit area é o .sheet__grab inteiro */
+  .sheet__grab::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     width: 48px;
     height: 5px;
     border-radius: 3px;
     background: var(--color-border);
-    margin: 10px auto 8px;
-    flex: 0 0 auto;
-    cursor: grab;
   }
 
   .sheet__grab:active {


### PR DESCRIPTION
## Contexto

Dois ajustes no bottom sheet do mobile (`components/explore/MobileSheet.vue`), reportados em uso real:

1. **O gesto de drag não respondia facilmente.**
2. **O sheet iniciava cobrindo muito do mapa.**

## O que muda

### Drag mais responsivo
A área que disparava o arraste era só o handle de **48×5px** — e como `margin` não conta como hit area, o alvo real era uma faixa de 5px de altura, quase impossível de acertar com o dedo.

- `.sheet__grab` agora tem `height: 28px` e largura total; a barrinha visual (48×5) é desenhada via `::before`. **Visual idêntico, área de toque ~6× maior.**
- `setPointerCapture` no `pointerdown` — mantém o stream de pointer events mesmo se o dedo escorregar para fora do handle no meio do arraste.
- Trata `pointercancel` (antes não tratado): se o browser cancelava o gesto, o estado `dragging` ficava preso, com listeners vazando e o sheet sem transição. Agora finaliza o drag igual ao `pointerup`, incluindo limpeza no `onBeforeUnmount`.
- `touch-action: none` explícito no handle (defensivo).

### Snap inicial mais baixo
- Estado inicial muda de `half` (`translateY(45%)`) para `peek` (`translateY(calc(100% - 132px))`), revelando quase todo o mapa na primeira tela.
- Mantém os 3 snaps da spec; usa um já existente. A seleção de pino no mapa continua subindo o sheet para `half` automaticamente (via `watch` do `selectedGroupSlug`).

## Teste
- `npm run dev` em modo mobile (DevTools responsivo / dispositivo real): conferir que o handle pega o toque com facilidade, que o drag encaixa nos snaps ao soltar, e que o mapa aparece mais na carga inicial.
- `eslint` do arquivo: limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)