### PR TITLE
chore(netlify): noindex nos branch deploys (staging da develop)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,13 @@
 [build.environment]
   NODE_VERSION = "22"
 
+# Branch deploys (ex.: staging da `develop`) não devem ser indexados pelo Google.
+# O Netlify não suporta headers por contexto direto no toml ([[headers]] é global),
+# então neste contexto copiamos um arquivo _headers só com X-Robots-Tag: noindex
+# para o diretório publicado. Produção (main) não recebe esse arquivo.
+[context.branch-deploy]
+  command = "yarn generate && cp ./netlify/_branch_headers .output/public/_headers"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/_branch_headers
+++ b/netlify/_branch_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
## Contexto

Para termos um **deploy de staging da `develop`** no Netlify (hoje só existe deploy de produção na `main` e Deploy Preview de PRs contra a `main`), vamos habilitar **Branch Deploys** para a `develop`. Como o URL de staging (`develop--pedalasampa.netlify.app`) é público, este PR garante que ele **não seja indexado pelo Google**.

## Por que não foi via `[context.branch-deploy.headers]`

O Netlify **não suporta headers por contexto** direto no `netlify.toml` — o bloco `[[headers]]` é sempre **global** (pegaria a produção também). Confirmado na doc oficial. A forma documentada é sobrescrever o `command` apenas no contexto `branch-deploy` para copiar um `_headers` específico para o diretório publicado.

## O que muda

- `netlify.toml`: novo `[context.branch-deploy]` que roda `yarn generate` e copia `netlify/_branch_headers` → `.output/public/_headers`. Produção (`main`) **não** recebe esse header.
- `netlify/_branch_headers`: arquivo com `X-Robots-Tag: noindex` para `/*`.

## Ação manual necessária (fora do repo)

Habilitar o Branch Deploy da `develop` na UI do Netlify:
**Site configuration → Build & deploy → Continuous deployment → Branches and deploy contexts** → adicionar `develop` (ou "Deploy all branches").

Com isso: todo merge na `develop` publica no staging, e PRs `feature→develop` passam a ganhar Deploy Preview também.

## Verificação pós-deploy

Após o primeiro branch deploy da `develop`, conferir o header:
```
curl -sI https://develop--pedalasampa.netlify.app/ | grep -i x-robots-tag
# esperado: x-robots-tag: noindex
```
E confirmar que produção **não** tem o header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)