### PR TITLE
Promove para produção: fix do bottom sheet (mobile) + config de staging (#76, #77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ sw.*
 .env.local
 .env.production
 .env.development
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -4,19 +4,99 @@
 
 > :bicyclist: Descubra os grupos de pedal perto de você na cidade de São Paulo :mountain_bicyclist:
 
-> **Pedala Sampa** é um mapa colaborativo que visa ajudar os ciclistas da cidade de **São Paulo** a encontrar grupos de pedal próximos da sua casa ou trabalho.
+**Pedala Sampa** é um mapa colaborativo que ajuda ciclistas de **São Paulo** a encontrar grupos de pedal por região, dia, horário, nível, distância e ritmo — perto de casa ou do trabalho.
 
-> #bike #micromobilidade #mapacolaborativo #app  
+🔗 **Produção:** [pedalasampa.netlify.app](https://pedalasampa.netlify.app)
+
+> `#bike` `#micromobilidade` `#mapacolaborativo`
+
+## Sobre
+
+O projeto passou por uma **migração para Nuxt 3** e um **redesign completo** (direção *wayfinding* — inspirada na sinalização urbana). Principais características:
+
+- 🗺️ **Mapa-foco** — mapa interativo (Leaflet) com os pontos de saída dos grupos.
+- 🔎 **Filtros** — explore por região, dia, horário, nível, distância e ritmo.
+- 📄 **Página de grupo** — detalhes de cada grupo (agenda, ponto de saída, métricas).
+- 🎨 **Dois temas** — *Ciclovia* (claro, padrão) e *Noturno* (escuro).
+- ♿ **Acessibilidade** — foco visível, navegação por teclado e `prefers-reduced-motion`.
+- 🤝 **Colaborativo** — qualquer pessoa pode sugerir novos grupos ou correções.
+
+## Stack
+
+- [Nuxt 3](https://nuxt.com/) + [Vue 3](https://vuejs.org/) + TypeScript
+- [Leaflet](https://leafletjs.com/) (`@nuxtjs/leaflet`) para o mapa
+- [Hygraph](https://hygraph.com/) (GraphQL) como CMS dos grupos, via `graphql-request`
+- [`@nuxtjs/color-mode`](https://color-mode.nuxtjs.org/) para os temas
+- [Vitest](https://vitest.dev/) + [`@nuxt/test-utils`](https://nuxt.com/docs/getting-started/testing) para testes
+- ESLint (`@nuxt/eslint`) e `vue-tsc` para qualidade/tipos
+- Deploy estático no [Netlify](https://www.netlify.com/)
+
+## Como rodar
+
+> Requer **Node 22** (≥ 20.19) e [Yarn](https://yarnpkg.com/).
+
+```bash
+# instalar dependências
+yarn install
+
+# ambiente de desenvolvimento (http://localhost:3000)
+yarn dev
+```
+
+### Variáveis de ambiente
+
+Crie um arquivo `.env` na raiz:
+
+```env
+# Endpoint GraphQL do Hygraph (já tem um fallback público no nuxt.config)
+HYGRAPH_ENDPOINT=
+# Token do Hygraph (apenas se o conteúdo for protegido)
+GRAPHQL_TOKEN=
+# URL do formulário de contribuição (novo grupo / correção)
+NUXT_PUBLIC_CONTRIBUTION_FORM_URL=
+```
+
+## Scripts
+
+| Comando | Descrição |
+|---|---|
+| `yarn dev` | Servidor de desenvolvimento |
+| `yarn build` | Build de produção (SSR/Nitro) |
+| `yarn generate` | Geração estática (usado no deploy) |
+| `yarn preview` | Preview do build local |
+| `yarn lint` | ESLint |
+| `yarn test` | Testes (Vitest) |
+
+## Estrutura
+
+```
+components/   # UI por domínio (app, map, explore, group, contribution, ui)
+composables/  # lógica reutilizável (filtros, fetch de grupos)
+pages/        # rotas: / (mapa), /about, /group/[slug]
+layouts/      # layout padrão (header)
+queries/      # queries GraphQL do Hygraph
+lib/ types/   # utilitários e tipos
+assets/css/   # estilos globais e de componentes
+tests/        # testes unitários (Vitest)
+docs/redesign/# spec e handoff do redesign
+```
+
+## Deploy
+
+Deploy contínuo no **Netlify** a partir da branch de produção:
+
+- Comando: `yarn generate` · Publicação: `.output/public`
+- `NODE_VERSION = "22"` fixado no `netlify.toml`
+
+## Contribuir
+
+Quer adicionar um grupo ou corrigir uma informação? Use o formulário de contribuição no próprio site (botões *Sugerir grupo* / *Sugerir correção*).
 
 ## Desenvolvedor :computer:
 
-*  **Adams Alves** - [https://github.com/adamsalves](https://github.com/adamsalves)
-*  Quer contribuir? Entre em contato comigo pelo e-mail contato@adamsalves.com.br :)
+- **Adams Alves** — [github.com/adamsalves](https://github.com/adamsalves)
+- Contato: contato@adamsalves.com.br
 
-## Gostou do projeto, me apoie no Ko-fi :raised_hands: :coffee:
+## Apoie no Ko-fi :raised_hands: :coffee:
 
-- [https://ko-fi.com/adamsalves](https://ko-fi.com/adamsalves)
-
-## Status
-
-> :construction: Em desenvolvimento :building_construction:
+- [ko-fi.com/adamsalves](https://ko-fi.com/adamsalves)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Quer adicionar um grupo ou corrigir uma informação? Use o formulário de contr
 ## Desenvolvedor :computer:
 
 - **Adams Alves** — [github.com/adamsalves](https://github.com/adamsalves)
-- Contato: contato@adamsalves.com.br
+- Contato: [linkedin.com/in/adams-alves](https://www.linkedin.com/in/adams-alves/)
 
 ## Apoie no Ko-fi :raised_hands: :coffee:
 

--- a/components/explore/MobileSheet.vue
+++ b/components/explore/MobileSheet.vue
@@ -97,7 +97,7 @@ const PEEK_OFFSET = 132
 
 const sheetRef = ref<HTMLElement | null>(null)
 const bodyRef = ref<HTMLElement | null>(null)
-const snap = ref<Snap>('half')
+const snap = ref<Snap>('peek')
 const dragging = ref(false)
 
 let startY = 0
@@ -125,8 +125,14 @@ function onPointerDown(event: PointerEvent) {
   moved = false
   startY = event.clientY
   startTop = sheet.getBoundingClientRect().top
+  // garante que o stream de pointer events continue chegando mesmo se o dedo
+  // sair do handle durante o arraste
+  if (event.target instanceof Element) {
+    event.target.setPointerCapture(event.pointerId)
+  }
   window.addEventListener('pointermove', onPointerMove, { passive: false })
   window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerUp)
 }
 
 function onPointerMove(event: PointerEvent) {
@@ -150,6 +156,7 @@ function onPointerMove(event: PointerEvent) {
 function onPointerUp() {
   window.removeEventListener('pointermove', onPointerMove)
   window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
   dragging.value = false
 
   const sheet = sheetRef.value
@@ -194,6 +201,7 @@ watch(
 onBeforeUnmount(() => {
   window.removeEventListener('pointermove', onPointerMove)
   window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
 })
 </script>
 
@@ -238,13 +246,25 @@ onBeforeUnmount(() => {
   }
 
   .sheet__grab {
+    position: relative;
+    width: 100%;
+    height: 28px;
+    flex: 0 0 auto;
+    cursor: grab;
+    touch-action: none;
+  }
+
+  /* barrinha visual (48×5) centralizada — a hit area é o .sheet__grab inteiro */
+  .sheet__grab::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     width: 48px;
     height: 5px;
     border-radius: 3px;
     background: var(--color-border);
-    margin: 10px auto 8px;
-    flex: 0 0 auto;
-    cursor: grab;
   }
 
   .sheet__grab:active {

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,13 @@
 [build.environment]
   NODE_VERSION = "22"
 
+# Branch deploys (ex.: staging da `develop`) não devem ser indexados pelo Google.
+# O Netlify não suporta headers por contexto direto no toml ([[headers]] é global),
+# então neste contexto copiamos um arquivo _headers só com X-Robots-Tag: noindex
+# para o diretório publicado. Produção (main) não recebe esse arquivo.
+[context.branch-deploy]
+  command = "yarn generate && cp ./netlify/_branch_headers .output/public/_headers"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/_branch_headers
+++ b/netlify/_branch_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
     "typescript": "latest",
     "vitest": "latest",
     "vue-tsc": "latest"
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.6",
+    "browserslist": "^4.16.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4827,9 +4827,9 @@ lodash.uniq@^4.5.0:
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@^4.17.15:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 lru-cache@^10.2.0:
   version "10.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,18 +2891,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
-  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
-  dependencies:
-    caniuse-lite "^1.0.30001181"
-    colorette "^1.2.1"
-    electron-to-chromium "^1.3.649"
-    escalade "^3.1.1"
-    node-releases "^1.1.70"
-
-browserslist@^4.24.0, browserslist@^4.28.1, browserslist@^4.28.2:
+browserslist@^4.0.0, browserslist@^4.16.5, browserslist@^4.24.0, browserslist@^4.28.1, browserslist@^4.28.2:
   version "4.28.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
   integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
@@ -2988,7 +2977,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001181:
+caniuse-lite@^1.0.0:
   version "1.0.30001194"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz#3d16ff3d734a5a7d9818402c28b1f636c5be5bed"
   integrity sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==
@@ -3076,11 +3065,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-colorette@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 commander@^10.0.0:
   version "10.0.1"
@@ -3201,16 +3185,7 @@ croner@^10.0.1:
   resolved "https://registry.yarnpkg.com/croner/-/croner-10.0.1.tgz#4eb92806c99539146dbe2f3ee3907e319cb2847a"
   integrity sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==
 
-cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
-cross-spawn@^7.0.6:
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -3482,11 +3457,6 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-
-electron-to-chromium@^1.3.649:
-  version "1.3.679"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.679.tgz#69b45bbf1e0bc2320cb1f3e65b9283e86c4d5e2f"
-  integrity sha512-PNF7JSPAEa/aV2nQLvflRcnIMy31EOuCY87Jbdz0KsUf8O/eFNGpuwgQn2DmyJkKzfQb0zrieanRGWvf/4H+BA==
 
 electron-to-chromium@^1.5.328:
   version "1.5.364"
@@ -5131,11 +5101,6 @@ node-mock-http@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/node-mock-http/-/node-mock-http-1.0.4.tgz#21f2ab4ce2fe4fbe8a660d7c5195a1db85e042a4"
   integrity sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==
-
-node-releases@^1.1.70:
-  version "1.1.71"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
-  integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
 node-releases@^2.0.36:
   version "2.0.46"


### PR DESCRIPTION
## Promoção develop → main

Leva à produção as mudanças acumuladas na `develop`. O diff efetivo entre os tips é de **3 arquivos** (os demais commits do histórico — README, segurança, housekeeping — já chegaram na `main` via #75).

### O que muda em produção

**#76 — fix do bottom sheet no mobile** (`components/explore/MobileSheet.vue`)
- Área de toque do handle de drag ampliada (era 48×5px, quase impossível de acertar com o dedo) → faixa de 28px com a barrinha desenhada via `::before` (visual idêntico).
- `setPointerCapture` + tratamento de `pointercancel` para o drag não travar/vazar estado.
- Snap inicial muda de `half` para `peek`, revelando mais mapa na primeira tela.

**#77 — staging da develop sem indexação** (`netlify.toml`, `netlify/_branch_headers`)
- Contexto `branch-deploy` copia um `_headers` com `X-Robots-Tag: noindex`. **Não afeta produção** (`main` não recebe esse header) — é só infra para o ambiente de staging da `develop`.

### Verificação
- `eslint` limpo nos arquivos alterados.
- Após o deploy-preview do Netlify ficar verde, vale conferir no preview o gesto de drag e o novo snap inicial no mobile antes de mergear.

## Gate
PR contra a `main`: só mergeia com o check `netlify/pedalasampa/deploy-preview` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)