### PR TITLE
style(header): remover canto chanfrado e deixar a barra chapada

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -61,7 +61,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* ---------- App header (asphalt bar, angular cut corner) ---------- */
+/* ---------- App header (asphalt bar) ---------- */
 .ps-header {
   display: flex;
   align-items: center;
@@ -71,7 +71,6 @@
   padding: 0 var(--space-6);
   background: var(--header-bg);
   color: var(--header-fg);
-  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 8px), calc(100% - 32px) 100%, 0 100%);
 }
 .ps-brand {
   display: inline-flex;

--- a/components/app/AppHeader.vue
+++ b/components/app/AppHeader.vue
@@ -189,7 +189,6 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocumentClick))
 @media (max-width: 760px) {
   .ps-header {
     padding: 0 var(--space-4);
-    clip-path: none;
   }
 
   .nav-desktop,


### PR DESCRIPTION
## Contexto

O header tinha um `clip-path` que recortava o canto inferior direito em diagonal (32×8px) — o detalhe "angular cut corner" do handoff do redesign wayfinding. Na prática, no tema claro (ciclovia) o recorte revela o fundo claro da página como um triângulo ao lado do CTA "Sugerir Grupo", e nesse tamanho discreto ele lê como **glitch de layout**, não como detalhe de sinalização; no tema noturno o fundo escuro o esconde por completo, reforçando a impressão de inconsistência entre temas. Decisão: remover o chanfro e deixar o header como um retângulo chapado.

## Implementação

- `assets/css/components.css`: removido o `clip-path` do `.ps-header` (e atualizado o comentário da seção, que mencionava o "angular cut corner").
- `components/app/AppHeader.vue`: removido o `clip-path: none` da media query mobile — o override só existia para desligar o chanfro no mobile e perdeu a razão de ser.

Nota: o protótipo em `docs/redesign/design_handoff_pedala_sampa/` continua descrevendo o "angular header" — a documentação do handoff é registro histórico e não foi alterada.

## Test plan

- [x] `yarn lint` e `yarn test` (27 testes) passando
- [x] Visual no Chrome (tema claro, desktop): header fecha reto até o canto, sem o triângulo ao lado do CTA
- [x] Smoke: conferir tema noturno e mobile (não devem ter mudança visível — o chanfro já era invisível/desligado neles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)