### PR TITLE
release: fixes do mapa e mobile + infra Netlify e docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ sw.*
 .env.local
 .env.production
 .env.development
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -4,19 +4,99 @@
 
 > :bicyclist: Descubra os grupos de pedal perto de você na cidade de São Paulo :mountain_bicyclist:
 
-> **Pedala Sampa** é um mapa colaborativo que visa ajudar os ciclistas da cidade de **São Paulo** a encontrar grupos de pedal próximos da sua casa ou trabalho.
+**Pedala Sampa** é um mapa colaborativo que ajuda ciclistas de **São Paulo** a encontrar grupos de pedal por região, dia, horário, nível, distância e ritmo — perto de casa ou do trabalho.
 
-> #bike #micromobilidade #mapacolaborativo #app  
+🔗 **Produção:** [pedalasampa.netlify.app](https://pedalasampa.netlify.app)
+
+> `#bike` `#micromobilidade` `#mapacolaborativo`
+
+## Sobre
+
+O projeto passou por uma **migração para Nuxt 3** e um **redesign completo** (direção *wayfinding* — inspirada na sinalização urbana). Principais características:
+
+- 🗺️ **Mapa-foco** — mapa interativo (Leaflet) com os pontos de saída dos grupos.
+- 🔎 **Filtros** — explore por região, dia, horário, nível, distância e ritmo.
+- 📄 **Página de grupo** — detalhes de cada grupo (agenda, ponto de saída, métricas).
+- 🎨 **Dois temas** — *Ciclovia* (claro, padrão) e *Noturno* (escuro).
+- ♿ **Acessibilidade** — foco visível, navegação por teclado e `prefers-reduced-motion`.
+- 🤝 **Colaborativo** — qualquer pessoa pode sugerir novos grupos ou correções.
+
+## Stack
+
+- [Nuxt 3](https://nuxt.com/) + [Vue 3](https://vuejs.org/) + TypeScript
+- [Leaflet](https://leafletjs.com/) (`@nuxtjs/leaflet`) para o mapa
+- [Hygraph](https://hygraph.com/) (GraphQL) como CMS dos grupos, via `graphql-request`
+- [`@nuxtjs/color-mode`](https://color-mode.nuxtjs.org/) para os temas
+- [Vitest](https://vitest.dev/) + [`@nuxt/test-utils`](https://nuxt.com/docs/getting-started/testing) para testes
+- ESLint (`@nuxt/eslint`) e `vue-tsc` para qualidade/tipos
+- Deploy estático no [Netlify](https://www.netlify.com/)
+
+## Como rodar
+
+> Requer **Node 22** (≥ 20.19) e [Yarn](https://yarnpkg.com/).
+
+```bash
+# instalar dependências
+yarn install
+
+# ambiente de desenvolvimento (http://localhost:3000)
+yarn dev
+```
+
+### Variáveis de ambiente
+
+Crie um arquivo `.env` na raiz:
+
+```env
+# Endpoint GraphQL do Hygraph (já tem um fallback público no nuxt.config)
+HYGRAPH_ENDPOINT=
+# Token do Hygraph (apenas se o conteúdo for protegido)
+GRAPHQL_TOKEN=
+# URL do formulário de contribuição (novo grupo / correção)
+NUXT_PUBLIC_CONTRIBUTION_FORM_URL=
+```
+
+## Scripts
+
+| Comando | Descrição |
+|---|---|
+| `yarn dev` | Servidor de desenvolvimento |
+| `yarn build` | Build de produção (SSR/Nitro) |
+| `yarn generate` | Geração estática (usado no deploy) |
+| `yarn preview` | Preview do build local |
+| `yarn lint` | ESLint |
+| `yarn test` | Testes (Vitest) |
+
+## Estrutura
+
+```
+components/   # UI por domínio (app, map, explore, group, contribution, ui)
+composables/  # lógica reutilizável (filtros, fetch de grupos)
+pages/        # rotas: / (mapa), /about, /group/[slug]
+layouts/      # layout padrão (header)
+queries/      # queries GraphQL do Hygraph
+lib/ types/   # utilitários e tipos
+assets/css/   # estilos globais e de componentes
+tests/        # testes unitários (Vitest)
+docs/redesign/# spec e handoff do redesign
+```
+
+## Deploy
+
+Deploy contínuo no **Netlify** a partir da branch de produção:
+
+- Comando: `yarn generate` · Publicação: `.output/public`
+- `NODE_VERSION = "22"` fixado no `netlify.toml`
+
+## Contribuir
+
+Quer adicionar um grupo ou corrigir uma informação? Use o formulário de contribuição no próprio site (botões *Sugerir grupo* / *Sugerir correção*).
 
 ## Desenvolvedor :computer:
 
-*  **Adams Alves** - [https://github.com/adamsalves](https://github.com/adamsalves)
-*  Quer contribuir? Entre em contato comigo pelo e-mail contato@adamsalves.com.br :)
+- **Adams Alves** — [github.com/adamsalves](https://github.com/adamsalves)
+- Contato: contato@adamsalves.com.br
 
-## Gostou do projeto, me apoie no Ko-fi :raised_hands: :coffee:
+## Apoie no Ko-fi :raised_hands: :coffee:
 
-- [https://ko-fi.com/adamsalves](https://ko-fi.com/adamsalves)
-
-## Status
-
-> :construction: Em desenvolvimento :building_construction:
+- [ko-fi.com/adamsalves](https://ko-fi.com/adamsalves)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Quer adicionar um grupo ou corrigir uma informação? Use o formulário de contr
 ## Desenvolvedor :computer:
 
 - **Adams Alves** — [github.com/adamsalves](https://github.com/adamsalves)
-- Contato: contato@adamsalves.com.br
+- Contato: [linkedin.com/in/adams-alves](https://www.linkedin.com/in/adams-alves/)
 
 ## Apoie no Ko-fi :raised_hands: :coffee:
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -61,7 +61,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* ---------- App header (asphalt bar, angular cut corner) ---------- */
+/* ---------- App header (asphalt bar) ---------- */
 .ps-header {
   display: flex;
   align-items: center;
@@ -71,7 +71,6 @@
   padding: 0 var(--space-6);
   background: var(--header-bg);
   color: var(--header-fg);
-  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 8px), calc(100% - 32px) 100%, 0 100%);
 }
 .ps-brand {
   display: inline-flex;

--- a/components/app/AppHeader.vue
+++ b/components/app/AppHeader.vue
@@ -189,7 +189,6 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocumentClick))
 @media (max-width: 760px) {
   .ps-header {
     padding: 0 var(--space-4);
-    clip-path: none;
   }
 
   .nav-desktop,

--- a/components/explore/MobileSheet.vue
+++ b/components/explore/MobileSheet.vue
@@ -97,7 +97,7 @@ const PEEK_OFFSET = 132
 
 const sheetRef = ref<HTMLElement | null>(null)
 const bodyRef = ref<HTMLElement | null>(null)
-const snap = ref<Snap>('half')
+const snap = ref<Snap>('peek')
 const dragging = ref(false)
 
 let startY = 0
@@ -125,8 +125,14 @@ function onPointerDown(event: PointerEvent) {
   moved = false
   startY = event.clientY
   startTop = sheet.getBoundingClientRect().top
+  // garante que o stream de pointer events continue chegando mesmo se o dedo
+  // sair do handle durante o arraste
+  if (event.target instanceof Element) {
+    event.target.setPointerCapture(event.pointerId)
+  }
   window.addEventListener('pointermove', onPointerMove, { passive: false })
   window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerUp)
 }
 
 function onPointerMove(event: PointerEvent) {
@@ -150,6 +156,7 @@ function onPointerMove(event: PointerEvent) {
 function onPointerUp() {
   window.removeEventListener('pointermove', onPointerMove)
   window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
   dragging.value = false
 
   const sheet = sheetRef.value
@@ -194,6 +201,7 @@ watch(
 onBeforeUnmount(() => {
   window.removeEventListener('pointermove', onPointerMove)
   window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
 })
 </script>
 
@@ -238,13 +246,25 @@ onBeforeUnmount(() => {
   }
 
   .sheet__grab {
+    position: relative;
+    width: 100%;
+    height: 28px;
+    flex: 0 0 auto;
+    cursor: grab;
+    touch-action: none;
+  }
+
+  /* barrinha visual (48×5) centralizada — a hit area é o .sheet__grab inteiro */
+  .sheet__grab::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     width: 48px;
     height: 5px;
     border-radius: 3px;
     background: var(--color-border);
-    margin: 10px auto 8px;
-    flex: 0 0 auto;
-    cursor: grab;
   }
 
   .sheet__grab:active {

--- a/components/explore/MobileSheet.vue
+++ b/components/explore/MobileSheet.vue
@@ -37,7 +37,7 @@
       </div>
     </div>
 
-    <div ref="bodyRef" class="sheet__body">
+    <div ref="bodyRef" class="sheet__body" @focusin="onBodyFocusin">
       <template v-if="groups.length">
         <GroupCard
           v-for="group in groups"
@@ -107,6 +107,15 @@ let moved = false
 function cycleSnap() {
   const index = SNAPS.indexOf(snap.value)
   snap.value = index >= SNAPS.length - 1 ? 'peek' : SNAPS[index + 1]
+}
+
+// keyboard/screen-reader focus entering the list raises the sheet: the .home
+// container is overflow: clip (won't scroll), so at peek a focused card would
+// stay invisible below the fold — the body's own scroll then reveals the card
+function onBodyFocusin() {
+  if (snap.value === 'peek') {
+    snap.value = 'half'
+  }
 }
 
 function onGrabKeydown(event: KeyboardEvent) {

--- a/components/map/GroupMap.client.vue
+++ b/components/map/GroupMap.client.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import type { LeafletMouseEvent, Map as LeafletMap, PointTuple } from 'leaflet'
+import type { FitBoundsOptions, LatLngTuple, LeafletMouseEvent, Map as LeafletMap, PointTuple } from 'leaflet'
 import { watch } from 'vue'
 import { prefersReducedMotion } from '../../lib/motion'
 import type { Group } from '../../types/group'
@@ -87,6 +87,37 @@ function onMarkerClick(slug: string, event: LeafletMouseEvent) {
   event.originalEvent.stopPropagation()
   emit('select', slug)
 }
+
+// refit the map around the remaining pins whenever the filters change the list
+function fitToGroups(map: LeafletMap) {
+  const points: LatLngTuple[] = props.groups.map((group) => [
+    group.departureLocation.latitude,
+    group.departureLocation.longitude,
+  ])
+  if (!points.length) {
+    return
+  }
+  const options: FitBoundsOptions = {
+    paddingTopLeft: [48, 48],
+    // on mobile the bottom sheet covers the lower area, so pad it out of the fit
+    paddingBottomRight: [48, isMobileViewport() ? map.getSize().y * 0.4 : 48],
+    maxZoom: FLY_ZOOM,
+  }
+  if (prefersReducedMotion()) {
+    map.fitBounds(points, options)
+  } else {
+    map.flyToBounds(points, { ...options, duration: 0.6 })
+  }
+}
+
+watch(
+  () => props.groups.map((group) => group.slug).join(','),
+  () => {
+    if (mapInstance) {
+      fitToGroups(mapInstance)
+    }
+  },
+)
 
 // fly to the selected group whenever the selection changes (card or pin)
 watch(

--- a/components/map/GroupMap.client.vue
+++ b/components/map/GroupMap.client.vue
@@ -33,8 +33,9 @@
 </template>
 
 <script setup lang="ts">
-import type { FitBoundsOptions, LatLngTuple, LeafletMouseEvent, Map as LeafletMap, PointTuple } from 'leaflet'
-import { watch } from 'vue'
+import type { LatLngTuple, LeafletMouseEvent, Map as LeafletMap, PointTuple } from 'leaflet'
+import { onBeforeUnmount, watch } from 'vue'
+import { FLY_ZOOM, SHEET_OVERLAP, buildFitOptions, groupsToPoints } from '../../lib/map-bounds'
 import { prefersReducedMotion } from '../../lib/motion'
 import type { Group } from '../../types/group'
 import MapTileLayer from './MapTileLayer.vue'
@@ -50,7 +51,7 @@ const emit = defineEmits<{
 }>()
 
 // aligns with the prototype (PS.CENTER / PS.ZOOM)
-const CENTER: PointTuple = [-23.576, -46.655]
+const CENTER: LatLngTuple = [-23.576, -46.655]
 const ZOOM = 12
 
 const defaultSize: PointTuple = [28, 28]
@@ -58,28 +59,42 @@ const defaultAnchor: PointTuple = [14, 26]
 const selectedSize: PointTuple = [36, 36]
 const selectedAnchor: PointTuple = [18, 34]
 
-const FLY_ZOOM = 14
+// debounce so typing in the search box doesn't fire one refit per keystroke
+const FIT_DEBOUNCE_MS = 300
 
 let mapInstance: LeafletMap | null = null
+let fitTimer: ReturnType<typeof setTimeout> | null = null
+// a filter change can land before the map is ready — remember it for onMapReady
+let pendingFit = false
 
 // mobile: the bottom sheet covers the lower half, so a centred pin lands behind
 // it — shift the map centre down so the pin sits in the visible upper area.
 const isMobileViewport = () =>
   typeof window !== 'undefined' && window.matchMedia('(max-width: 760px)').matches
 
-function flyTarget(map: LeafletMap, latlng: PointTuple): PointTuple {
+// half the sheet overlap puts the pin at the same height as a fitted single pin
+function flyTarget(map: LeafletMap, latlng: LatLngTuple): LatLngTuple {
   if (!isMobileViewport()) {
     return latlng
   }
   const point = map.project(latlng, FLY_ZOOM)
-  const center = map.unproject([point.x, point.y + map.getSize().y * 0.25], FLY_ZOOM)
+  const center = map.unproject(
+    [point.x, point.y + map.getSize().y * (SHEET_OVERLAP / 2)],
+    FLY_ZOOM,
+  )
   return [center.lat, center.lng]
 }
 
 function onMapReady(map: LeafletMap) {
   mapInstance = map
   // the map often mounts before its container has its final size
-  setTimeout(() => map.invalidateSize(), 60)
+  setTimeout(() => {
+    map.invalidateSize()
+    if (pendingFit) {
+      pendingFit = false
+      fitToGroups(map)
+    }
+  }, 60)
 }
 
 function onMarkerClick(slug: string, event: LeafletMouseEvent) {
@@ -90,19 +105,11 @@ function onMarkerClick(slug: string, event: LeafletMouseEvent) {
 
 // refit the map around the remaining pins whenever the filters change the list
 function fitToGroups(map: LeafletMap) {
-  const points: LatLngTuple[] = props.groups.map((group) => [
-    group.departureLocation.latitude,
-    group.departureLocation.longitude,
-  ])
+  const points = groupsToPoints(props.groups)
   if (!points.length) {
     return
   }
-  const options: FitBoundsOptions = {
-    paddingTopLeft: [48, 48],
-    // on mobile the bottom sheet covers the lower area, so pad it out of the fit
-    paddingBottomRight: [48, isMobileViewport() ? map.getSize().y * 0.4 : 48],
-    maxZoom: FLY_ZOOM,
-  }
+  const options = buildFitOptions(map.getSize().y, isMobileViewport())
   if (prefersReducedMotion()) {
     map.fitBounds(points, options)
   } else {
@@ -110,11 +117,39 @@ function fitToGroups(map: LeafletMap) {
   }
 }
 
-watch(
-  () => props.groups.map((group) => group.slug).join(','),
-  () => {
+function scheduleFit() {
+  if (fitTimer) {
+    clearTimeout(fitTimer)
+  }
+  fitTimer = setTimeout(() => {
+    fitTimer = null
     if (mapInstance) {
       fitToGroups(mapInstance)
+    } else {
+      pendingFit = true
+    }
+  }, FIT_DEBOUNCE_MS)
+}
+
+onBeforeUnmount(() => {
+  if (fitTimer) {
+    clearTimeout(fitTimer)
+  }
+})
+
+function sameGroupSet(next: Group[], prev: Group[]): boolean {
+  if (next.length !== prev.length) {
+    return false
+  }
+  const prevSlugs = new Set(prev.map((group) => group.slug))
+  return next.every((group) => prevSlugs.has(group.slug))
+}
+
+watch(
+  () => props.groups,
+  (next, prev) => {
+    if (!sameGroupSet(next, prev)) {
+      scheduleFit()
     }
   },
 )
@@ -130,7 +165,7 @@ watch(
     if (!group) {
       return
     }
-    const latlng: PointTuple = [group.departureLocation.latitude, group.departureLocation.longitude]
+    const latlng: LatLngTuple = [group.departureLocation.latitude, group.departureLocation.longitude]
     const target = flyTarget(mapInstance, latlng)
     if (prefersReducedMotion()) {
       mapInstance.setView(target, FLY_ZOOM)

--- a/lib/map-bounds.ts
+++ b/lib/map-bounds.ts
@@ -1,0 +1,29 @@
+import type { FitBoundsOptions, LatLngTuple } from 'leaflet'
+import type { GeoPoint } from '../types/group'
+
+/** Max zoom for programmatic moves (selection fly or filter refit). */
+export const FLY_ZOOM = 14
+
+/**
+ * Fraction of the map height the mobile bottom sheet may cover. Used as bottom
+ * padding when fitting bounds and (halved) as the centre shift when flying to a
+ * single pin, so the pin lands at the same height in both moves.
+ */
+export const SHEET_OVERLAP = 0.4
+
+const FIT_PADDING = 48
+
+export function groupsToPoints(groups: { departureLocation: GeoPoint }[]): LatLngTuple[] {
+  return groups.map((group) => [
+    group.departureLocation.latitude,
+    group.departureLocation.longitude,
+  ])
+}
+
+export function buildFitOptions(mapHeight: number, isMobile: boolean): FitBoundsOptions {
+  return {
+    paddingTopLeft: [FIT_PADDING, FIT_PADDING],
+    paddingBottomRight: [FIT_PADDING, isMobile ? mapHeight * SHEET_OVERLAP : FIT_PADDING],
+    maxZoom: FLY_ZOOM,
+  }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,13 @@
 [build.environment]
   NODE_VERSION = "22"
 
+# Branch deploys (ex.: staging da `develop`) não devem ser indexados pelo Google.
+# O Netlify não suporta headers por contexto direto no toml ([[headers]] é global),
+# então neste contexto copiamos um arquivo _headers só com X-Robots-Tag: noindex
+# para o diretório publicado. Produção (main) não recebe esse arquivo.
+[context.branch-deploy]
+  command = "yarn generate && cp ./netlify/_branch_headers .output/public/_headers"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/_branch_headers
+++ b/netlify/_branch_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
     "typescript": "latest",
     "vitest": "latest",
     "vue-tsc": "latest"
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.6",
+    "browserslist": "^4.16.5"
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -116,7 +116,10 @@ useSeoMeta({
 .home {
   position: relative;
   height: calc(100vh - var(--header-height));
-  overflow: hidden;
+  /* clip (não hidden): hidden mantém o container rolável programaticamente,
+     então focar algo do sheet abaixo da dobra (tap/teclado) rolava o .home e
+     empurrava a toolbar para fora da tela, sem como o usuário rolar de volta */
+  overflow: clip;
 }
 
 .home__map {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import EmptyState from '../components/explore/EmptyState.vue'
 import FiltersDrawer from '../components/explore/FiltersDrawer.vue'
 import GroupMap from '../components/map/GroupMap.client.vue'
@@ -86,6 +86,17 @@ const { filters, filteredGroups, activeCount, setQuery, toggleFilter, clearFilte
 const { selectedGroupSlug, selectedGroup, selectGroup, clearSelectedGroup } = useSelectedGroup(groups)
 
 const drawerOpen = ref(false)
+
+// a filter change can remove the selected group from the map/carousel — close
+// the quick view instead of leaving it pointing at a group that is not visible
+watch(filteredGroups, (visibleGroups) => {
+  if (
+    selectedGroupSlug.value &&
+    !visibleGroups.some((group) => group.slug === selectedGroupSlug.value)
+  ) {
+    clearSelectedGroup()
+  }
+})
 
 const days = computed(() => [
   ...new Set(groups.value.flatMap((group) => group.schedules.map((schedule) => schedule.day))),

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -118,7 +118,10 @@ useSeoMeta({
   height: calc(100vh - var(--header-height));
   /* clip (não hidden): hidden mantém o container rolável programaticamente,
      então focar algo do sheet abaixo da dobra (tap/teclado) rolava o .home e
-     empurrava a toolbar para fora da tela, sem como o usuário rolar de volta */
+     empurrava a toolbar para fora da tela, sem como o usuário rolar de volta.
+     clip exige Safari 16+ — o hidden logo acima é o fallback de cascade para
+     browsers antigos (não remover achando redundante) */
+  overflow: hidden;
   overflow: clip;
 }
 

--- a/tests/unit/map-bounds.test.ts
+++ b/tests/unit/map-bounds.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { FLY_ZOOM, SHEET_OVERLAP, buildFitOptions, groupsToPoints } from '../../lib/map-bounds'
+
+describe('groupsToPoints', () => {
+  it('retorna lista vazia para nenhum grupo', () => {
+    expect(groupsToPoints([])).toEqual([])
+  })
+
+  it('mapeia departureLocation para tuplas [lat, lng]', () => {
+    const groups = [
+      { departureLocation: { latitude: -23.55, longitude: -46.63 } },
+      { departureLocation: { latitude: -23.6, longitude: -46.7 } },
+    ]
+    expect(groupsToPoints(groups)).toEqual([
+      [-23.55, -46.63],
+      [-23.6, -46.7],
+    ])
+  })
+})
+
+describe('buildFitOptions', () => {
+  it('usa padding simétrico no desktop', () => {
+    const options = buildFitOptions(800, false)
+    expect(options.paddingTopLeft).toEqual([48, 48])
+    expect(options.paddingBottomRight).toEqual([48, 48])
+  })
+
+  it('reserva a faixa do bottom sheet no mobile', () => {
+    const options = buildFitOptions(800, true)
+    expect(options.paddingBottomRight).toEqual([48, 800 * SHEET_OVERLAP])
+  })
+
+  it('limita o zoom ao FLY_ZOOM para não estourar com um pin só', () => {
+    expect(buildFitOptions(800, false).maxZoom).toBe(FLY_ZOOM)
+    expect(FLY_ZOOM).toBe(14)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4827,9 +4827,9 @@ lodash.uniq@^4.5.0:
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@^4.17.15:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 lru-cache@^10.2.0:
   version "10.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,18 +2891,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
-  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
-  dependencies:
-    caniuse-lite "^1.0.30001181"
-    colorette "^1.2.1"
-    electron-to-chromium "^1.3.649"
-    escalade "^3.1.1"
-    node-releases "^1.1.70"
-
-browserslist@^4.24.0, browserslist@^4.28.1, browserslist@^4.28.2:
+browserslist@^4.0.0, browserslist@^4.16.5, browserslist@^4.24.0, browserslist@^4.28.1, browserslist@^4.28.2:
   version "4.28.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
   integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
@@ -2988,7 +2977,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001181:
+caniuse-lite@^1.0.0:
   version "1.0.30001194"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz#3d16ff3d734a5a7d9818402c28b1f636c5be5bed"
   integrity sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==
@@ -3076,11 +3065,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-colorette@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 commander@^10.0.0:
   version "10.0.1"
@@ -3201,16 +3185,7 @@ croner@^10.0.1:
   resolved "https://registry.yarnpkg.com/croner/-/croner-10.0.1.tgz#4eb92806c99539146dbe2f3ee3907e319cb2847a"
   integrity sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==
 
-cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
-cross-spawn@^7.0.6:
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -3482,11 +3457,6 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-
-electron-to-chromium@^1.3.649:
-  version "1.3.679"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.679.tgz#69b45bbf1e0bc2320cb1f3e65b9283e86c4d5e2f"
-  integrity sha512-PNF7JSPAEa/aV2nQLvflRcnIMy31EOuCY87Jbdz0KsUf8O/eFNGpuwgQn2DmyJkKzfQb0zrieanRGWvf/4H+BA==
 
 electron-to-chromium@^1.5.328:
   version "1.5.364"
@@ -5131,11 +5101,6 @@ node-mock-http@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/node-mock-http/-/node-mock-http-1.0.4.tgz#21f2ab4ce2fe4fbe8a660d7c5195a1db85e042a4"
   integrity sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==
-
-node-releases@^1.1.70:
-  version "1.1.71"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
-  integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
 node-releases@^2.0.36:
   version "2.0.46"


### PR DESCRIPTION
## Contexto

Leva para produção o acumulado da develop desde o último release: dois fixes de UX no fluxo principal do mapa (reenquadramento ao filtrar e o scroll fantasma que escondia a busca no mobile), o ajuste visual do header, melhorias no bottom sheet mobile, e a infraestrutura de staging no Netlify (branch deploy da develop com noindex) junto com atualizações de docs e dependências de segurança.

## O que entra

### Fixes de UX (mapa e mobile)
- **#79 — Mapa reenquadra ao filtrar**: ao mudar filtros, o mapa faz `fitBounds` animado sobre os pins resultantes (debounce de 300ms na digitação, `maxZoom` 14, padding para o bottom sheet, respeita reduced motion); a seleção é limpa quando o grupo selecionado sai do filtro; lógica pura extraída para `lib/map-bounds.ts` com testes.
- **#80 — Scroll fantasma no mobile**: focus-scroll no container `.home` (overflow hidden) empurrava a toolbar de busca para fora da tela após usar o drawer de filtros; corrigido com `overflow: clip` (+ fallback `hidden` para Safari ≤15) e a11y: foco entrando na lista do sheet sobe o snap para `half`.
- **#76 — Bottom sheet**: gesto de drag melhorado e snap inicial em `peek`.

### Visual
- **#81 — Header chapado**: removido o canto chanfrado (`clip-path`) que lia como glitch no tema claro.

### Infra e docs
- **#77 — Netlify**: branch deploy da develop (staging) com `X-Robots-Tag: noindex`; `.netlify/` ignorado (#70).
- **#73/#72 — Dependências**: alertas Dependabot resolvidos (cross-spawn, browserslist, lodash).
- **#74/#71 — README**: atualizado para o momento Nuxt 3 + redesign, contato via LinkedIn.

## Test plan

- [x] `yarn lint` e `yarn test` (27 testes) passando na develop
- [x] Fixes #79/#80/#81 verificados em browser (Chrome desktop e viewport mobile 390×844) durante os PRs
- [x] Smoke no branch deploy da develop (staging) antes do merge: filtrar → mapa reenquadra; drawer mobile → busca permanece visível; header sem chanfro nos dois temas
- [x] Pós-deploy: smoke rápido em produção (mapa, filtros, sheet mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)