### PR TITLE
ci: release-please deve mirar a main (target-branch)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,9 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # o default branch do repo é a develop; sem isto a action miraria nela.
+          # produção é a main, então os releases saem daqui.
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Hotfix do mecanismo de release.

O **default branch do repositório é a `develop`**, então o `release-please-action` (sem `target-branch` explícito) abriu a Release PR contra a `develop` — a #87, já **fechada**. Produção é a `main`, então os releases precisam sair de lá.

Este PR fixa **`target-branch: main`** no `release-please.yml`.

## Ao mergear

O push na `main` re-dispara o release-please — agora abrindo a **Release PR correta da `v1.1.0`** com base na `main` (changelog a partir do baseline `v1.0.0`).

> Mudança só de workflow; o conteúdo do site não muda (o Netlify republica a `main` idêntica).
