### PR TITLE
ci: auto-merge da Release PR (release em 1 decisão humana)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,25 +12,48 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Detecta se o PAT (RELEASE_PLEASE_TOKEN) está configurado.
+      # - SEM PAT: o fluxo degrada para o modo manual (release-please usa o
+      #   GITHUB_TOKEN e você mergeia a Release PR à mão). Nada quebra.
+      # - COM PAT: a Release PR é auto-mergeada (o GITHUB_TOKEN não dispara o run
+      #   seguinte que cria a tag/release — por isso o PAT é necessário).
+      - id: haspat
+        env:
+          PAT: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: echo "set=${PAT:+true}" >> "$GITHUB_OUTPUT"
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           # o default branch do repo é a develop; sem isto a action miraria nela.
           # produção é a main, então os releases saem daqui.
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Quando um release é efetivamente criado (a Release PR foi mergeada),
-      # sincroniza a develop com a main para ela carregar a versão + CHANGELOG.
-      # Roda na mesma execução do release-please (não depende de evento em cascata).
+      # COM PAT: auto-merge da Release PR assim que ela é aberta/atualizada.
+      # O push do merge (via PAT) dispara o run seguinte, que cria a tag/release.
+      - name: Auto-merge da Release PR
+        if: ${{ steps.haspat.outputs.set == 'true' && steps.release.outputs.pr && !steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          pr=${{ fromJSON(steps.release.outputs.pr).number }}
+          for i in 1 2 3 4 5 6; do
+            if gh pr merge --merge "$pr"; then exit 0; fi
+            echo "Release PR #$pr ainda não mergeável, tentativa $i..."; sleep 5
+          done
+          echo "::error::não foi possível auto-mergear a Release PR #$pr"; exit 1
+
+      # Quando o release é criado (a Release PR foi mergeada), sincroniza a
+      # develop com a main (versão + CHANGELOG). Roda na mesma execução.
       - uses: actions/checkout@v5
         if: ${{ steps.release.outputs.release_created }}
         with:
           ref: develop
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Back-merge main into develop
         if: ${{ steps.release.outputs.release_created }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,20 +103,26 @@ Usamos **[SemVer](https://semver.org/)** (`MAJOR.MINOR.PATCH`), partindo de
 ### Rotina de lançamento
 
 1. Trabalhe em `feature/*` → PR para **`develop`**.
-2. Pronto para publicar: PR **`develop` → `main`** (merge normal).
-3. O push na `main` faz o release-please abrir/atualizar uma **Release PR** que
-   bumpa a versão no `package.json` e atualiza o `CHANGELOG.md`.
-4. **Revise e mergeie a Release PR.** Isso cria a **tag** `vX.Y.Z` e a
-   **GitHub Release** automaticamente; o Netlify publica a `main`.
-5. **Back-merge automático:** ao criar o release, o próprio workflow do
-   release-please sincroniza a `develop` com a `main` (versão + CHANGELOG). Não é
-   preciso fazer nada. Se houver conflito (raro), o job falha e aí é só resolver
-   o merge `main → develop` à mão.
+2. **Pronto para publicar: PR `develop` → `main` e mergeie.** Esta é a sua única
+   decisão de release.
+3. O push na `main` faz o release-please abrir uma **Release PR** (bump no
+   `package.json` + `CHANGELOG.md`). Com o PAT configurado (ver abaixo), ela é
+   **auto-mergeada**; sem o PAT, você a mergeia à mão.
+4. Ao mergear a Release PR: **tag** `vX.Y.Z` + **GitHub Release** + **back-merge
+   automático** `main` → `develop` (a develop recebe versão + CHANGELOG). Tudo
+   automático. Se o back-merge conflitar (raro), o job falha e aí é só resolver o
+   merge `main → develop` à mão.
 
 > O `CHANGELOG.md` é **gerado** pelo release-please — não edite à mão.
 
 ### Configuração necessária no GitHub (uma vez)
 
-Em **Settings → Actions → General → Workflow permissions**: marque
-_Read and write permissions_ e **"Allow GitHub Actions to create and approve
-pull requests"** — sem isso o release-please não consegue abrir a Release PR.
+1. **Settings → Actions → General → Workflow permissions**: marque _Read and write
+   permissions_ e **"Allow GitHub Actions to create and approve pull requests"** —
+   sem isso o release-please não consegue abrir a Release PR.
+2. **Secret `RELEASE_PLEASE_TOKEN`** (opcional, liga o auto-merge da Release PR):
+   um **PAT fine-grained** com acesso só a este repositório e permissões
+   _Contents: Read and write_ + _Pull requests: Read and write_. Em **Settings →
+   Secrets and variables → Actions → New repository secret**. É necessário porque
+   o `GITHUB_TOKEN` não dispara o run que cria a tag/release. Sem o secret, o
+   fluxo segue funcionando — só exige que você mergeie a Release PR manualmente.


### PR DESCRIPTION
Promove para a main a mudança de workflow que liga o auto-merge da Release PR (PR #90). Mudança só de CI — não dispara release. Após mergear, criar o secret `RELEASE_PLEASE_TOKEN` (ver CONTRIBUTING) liga o auto-merge.