### PR TITLE
release: duração do pedal no formulário → v1.2.0

### DIFF
--- a/components/contribution/SuggestionGroupFields.vue
+++ b/components/contribution/SuggestionGroupFields.vue
@@ -242,7 +242,8 @@ const derivedRhythm = computed<number | null>(() => {
   return getRhythmFromDistanceAndDuration({ distanceKm, durationMinutes })
 })
 
-// o schema rejeita ritmo > 60; avisamos antes de enviar
+// avisamos antes de enviar; este limite precisa acompanhar o `.max(60)` do
+// `rhythmKmH` em payloadSchema (lib/suggestion-schemas.ts), que é o backstop real
 const rhythmTooHigh = computed(
   () => derivedRhythm.value !== null && derivedRhythm.value > 60,
 )

--- a/components/contribution/SuggestionGroupFields.vue
+++ b/components/contribution/SuggestionGroupFields.vue
@@ -108,6 +108,37 @@
     </div>
 
     <div class="ps-field-group suggestion-span">
+      <label class="ps-fieldlabel" :for="`${uid}-duration`"
+        >Duração aproximada (HH:MM)</label
+      >
+      <input
+        :id="`${uid}-duration`"
+        v-model="model.durationHhmm"
+        class="ps-input suggestion-duration-input"
+        type="time"
+        :aria-describedby="`${uid}-duration-hint`"
+      />
+      <p
+        :id="`${uid}-duration-hint`"
+        class="suggestion-hint"
+        :class="{ 'suggestion-hint--warn': rhythmTooHigh }"
+        aria-live="polite"
+      >
+        <template v-if="rhythmTyped">Usando o ritmo informado acima.</template>
+        <template v-else-if="derivedRhythm === null">
+          Não sabe o ritmo? Informe a duração e calculamos pela distância.
+        </template>
+        <template v-else-if="rhythmTooHigh">
+          Ritmo calculado (≈ {{ formatRhythm(derivedRhythm) }} km/h) parece alto
+          demais — confira a distância e a duração.
+        </template>
+        <template v-else>
+          Ritmo calculado: ≈ {{ formatRhythm(derivedRhythm) }} km/h.
+        </template>
+      </p>
+    </div>
+
+    <div class="ps-field-group suggestion-span">
       <span :id="`${uid}-point`" class="ps-fieldlabel">
         Ponto de saída no mapa {{ required ? '*' : '' }}
       </span>
@@ -171,8 +202,9 @@
 
 <script setup lang="ts">
 import { computed, useId } from 'vue'
-import { parseNumber } from '../../lib/suggestion-form'
+import { parseDurationToMinutes, parseNumber } from '../../lib/suggestion-form'
 import type { SuggestionFormFields } from '../../lib/suggestion-form'
+import { getRhythmFromDistanceAndDuration } from '../../lib/time'
 import LocationPicker from './LocationPicker.client.vue'
 
 withDefaults(
@@ -191,6 +223,33 @@ const hasPoint = computed(
     parseNumber(model.value.latitude) !== undefined &&
     parseNumber(model.value.longitude) !== undefined,
 )
+
+// o ritmo digitado tem precedência sobre a duração
+const rhythmTyped = computed(
+  () => parseNumber(model.value.rhythmKmH) !== undefined,
+)
+
+/** Ritmo derivado da distância + duração — só quando o ritmo não foi digitado. */
+const derivedRhythm = computed<number | null>(() => {
+  if (rhythmTyped.value) {
+    return null
+  }
+  const distanceKm = parseNumber(model.value.distanceKm)
+  const durationMinutes = parseDurationToMinutes(model.value.durationHhmm)
+  if (distanceKm === undefined || durationMinutes === null) {
+    return null
+  }
+  return getRhythmFromDistanceAndDuration({ distanceKm, durationMinutes })
+})
+
+// o schema rejeita ritmo > 60; avisamos antes de enviar
+const rhythmTooHigh = computed(
+  () => derivedRhythm.value !== null && derivedRhythm.value > 60,
+)
+
+function formatRhythm(value: number | null): string {
+  return value === null ? '' : String(value).replace('.', ',')
+}
 </script>
 
 <style scoped>
@@ -216,6 +275,14 @@ const hasPoint = computed(
   margin: 0;
   font-size: var(--text-xs);
   color: var(--color-asphalt-55);
+}
+
+.suggestion-hint--warn {
+  color: var(--color-alert-red);
+}
+
+.suggestion-duration-input {
+  max-width: 12rem;
 }
 
 .suggestion-map {

--- a/components/contribution/SuggestionGroupFields.vue
+++ b/components/contribution/SuggestionGroupFields.vue
@@ -120,8 +120,8 @@
       />
       <p
         :id="`${uid}-duration-hint`"
-        class="suggestion-hint"
-        :class="{ 'suggestion-hint--warn': rhythmTooHigh }"
+        class="suggestion-duration-hint"
+        :class="`suggestion-duration-hint--${durationHintTone}`"
         aria-live="polite"
       >
         <template v-if="rhythmTyped">Usando o ritmo informado acima.</template>
@@ -247,6 +247,18 @@ const rhythmTooHigh = computed(
   () => derivedRhythm.value !== null && derivedRhythm.value > 60,
 )
 
+// destaque (verde) no convite e no resultado; vermelho no aviso; discreto quando
+// o ritmo já foi digitado e a duração é ignorada
+const durationHintTone = computed(() => {
+  if (rhythmTooHigh.value) {
+    return 'warn'
+  }
+  if (rhythmTyped.value) {
+    return 'muted'
+  }
+  return 'accent'
+})
+
 function formatRhythm(value: number | null): string {
   return value === null ? '' : String(value).replace('.', ',')
 }
@@ -277,12 +289,30 @@ function formatRhythm(value: number | null): string {
   color: var(--color-asphalt-55);
 }
 
-.suggestion-hint--warn {
-  color: var(--color-alert-red);
-}
-
 .suggestion-duration-input {
   max-width: 12rem;
+}
+
+/* helper da duração: mais presente que os hints comuns, para a pessoa perceber
+   que pode preencher o ritmo pela duração */
+.suggestion-duration-hint {
+  margin: var(--space-1) 0 0;
+  font-size: var(--text-base);
+}
+
+.suggestion-duration-hint--accent {
+  color: var(--color-green-dark);
+  font-weight: 600;
+}
+
+.suggestion-duration-hint--warn {
+  color: var(--color-alert-red);
+  font-weight: 600;
+}
+
+.suggestion-duration-hint--muted {
+  font-size: var(--text-sm);
+  color: var(--color-asphalt-55);
 }
 
 .suggestion-map {

--- a/lib/suggestion-form.ts
+++ b/lib/suggestion-form.ts
@@ -118,6 +118,8 @@ export function payloadFromFields(
 
   // Sem ritmo digitado: deriva pela distância + duração informada (HH:MM).
   // O ritmo digitado tem precedência; a duração não é persistida no payload.
+  // (convenção: `parseNumber` devolve `undefined`; `parseDurationToMinutes` e
+  //  `getRhythmFromDistanceAndDuration` devolvem `null` — por isso os checks diferem.)
   if (payload.rhythmKmH === undefined && payload.distanceKm !== undefined) {
     const durationMinutes = parseDurationToMinutes(fields.durationHhmm)
     if (durationMinutes !== null) {

--- a/lib/suggestion-form.ts
+++ b/lib/suggestion-form.ts
@@ -1,4 +1,5 @@
 import type { GroupRecord, SuggestionGroupPayload } from '../types/suggestion'
+import { getRhythmFromDistanceAndDuration } from './time'
 
 /**
  * Estado dos inputs dos forms. Campos de texto são string; nos campos com
@@ -14,6 +15,9 @@ export type SuggestionFormFields = {
   effort: string
   distanceKm: string | number
   rhythmKmH: string | number
+  /** Duração aproximada do pedal no formato "HH:MM". Não vai ao payload — só
+   *  deriva o `rhythmKmH` quando a pessoa não sabe o ritmo em km/h. */
+  durationHhmm: string
   latitude: string | number
   longitude: string | number
 }
@@ -46,6 +50,7 @@ export function emptyFields(): SuggestionFormFields {
     effort: '',
     distanceKm: '',
     rhythmKmH: '',
+    durationHhmm: '',
     latitude: '',
     longitude: '',
   }
@@ -62,6 +67,8 @@ export function fieldsFromRecord(record: GroupRecord): SuggestionFormFields {
     distanceKm:
       record.distanceKm !== undefined ? String(record.distanceKm) : '',
     rhythmKmH: record.rhythmKmH !== undefined ? String(record.rhythmKmH) : '',
+    // o grupo publicado não guarda duração; o ritmo já vem preenchido acima
+    durationHhmm: '',
     latitude: String(record.latitude),
     longitude: String(record.longitude),
   }
@@ -80,6 +87,16 @@ export function parseNumber(value: string | number): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
+/** Converte uma duração "HH:MM" em minutos — `null` se vazio ou inválido. */
+export function parseDurationToMinutes(value: string): number | null {
+  const match = value.trim().match(/^(\d{1,2}):([0-5]\d)$/)
+  if (!match) {
+    return null
+  }
+  const total = Number(match[1]) * 60 + Number(match[2])
+  return total > 0 ? total : null
+}
+
 /** Converte os inputs em payload, descartando campos vazios. */
 export function payloadFromFields(
   fields: SuggestionFormFields,
@@ -96,6 +113,21 @@ export function payloadFromFields(
     const value = parseNumber(fields[field])
     if (value !== undefined) {
       payload[field] = value
+    }
+  }
+
+  // Sem ritmo digitado: deriva pela distância + duração informada (HH:MM).
+  // O ritmo digitado tem precedência; a duração não é persistida no payload.
+  if (payload.rhythmKmH === undefined && payload.distanceKm !== undefined) {
+    const durationMinutes = parseDurationToMinutes(fields.durationHhmm)
+    if (durationMinutes !== null) {
+      const derived = getRhythmFromDistanceAndDuration({
+        distanceKm: payload.distanceKm,
+        durationMinutes,
+      })
+      if (derived !== null) {
+        payload.rhythmKmH = derived
+      }
     }
   }
 

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -19,6 +19,26 @@ export function getEstimatedLapDuration({
   return `${String(hours).padStart(2, '0')}h:${String(minutes).padStart(2, '0')}m`
 }
 
+/**
+ * Inverso de `getEstimatedLapDuration`: ritmo médio (km/h) a partir da distância
+ * e da duração. Para quem sabe quanto tempo o pedal dura, mas não o km/h.
+ * `null` quando os dados não permitem o cálculo. Arredonda em 1 casa decimal.
+ */
+export function getRhythmFromDistanceAndDuration({
+  distanceKm,
+  durationMinutes,
+}: {
+  distanceKm: number
+  durationMinutes: number
+}): number | null {
+  if (!distanceKm || !durationMinutes || durationMinutes <= 0) {
+    return null
+  }
+
+  const rhythm = distanceKm / (durationMinutes / 60)
+  return Math.round(rhythm * 10) / 10
+}
+
 export function getPeriodFromHour(startHour: string): Period {
   const [rawHour] = startHour.split(':')
   const hour = Number(rawHour)

--- a/tests/unit/suggestion-form.test.ts
+++ b/tests/unit/suggestion-form.test.ts
@@ -96,6 +96,31 @@ describe('payloadFromFields', () => {
     }
     expect(payloadFromFields(fields)).toEqual({ name: 'Pedal Novo' })
   })
+
+  it('deriva o ritmo com distância em vírgula decimal', () => {
+    const fields = {
+      ...emptyFields(),
+      name: 'Pedal Novo',
+      distanceKm: '50,0',
+      durationHhmm: '02:30',
+    }
+    expect(payloadFromFields(fields)).toEqual({
+      name: 'Pedal Novo',
+      distanceKm: 50,
+      rhythmKmH: 20,
+    })
+  })
+
+  it('deriva ritmo acima de 60 sem clampar (o schema é o backstop)', () => {
+    const fields = {
+      ...emptyFields(),
+      name: 'Pedal Novo',
+      distanceKm: 60,
+      durationHhmm: '00:30', // 60 km em 30 min = 120 km/h
+    }
+    // não clampamos no form: o payloadSchema (rhythmKmH max 60) rejeita no envio
+    expect(payloadFromFields(fields).rhythmKmH).toBe(120)
+  })
 })
 
 describe('parseDurationToMinutes', () => {
@@ -141,5 +166,15 @@ describe('diffPayload', () => {
     fields.rhythmKmH = '20'
 
     expect(diffPayload(fields, record)).toEqual({ rhythmKmH: 20 })
+  })
+
+  it('deriva o ritmo da duração no diff quando o grupo não tinha ritmo', () => {
+    const recordNoRhythm: GroupRecord = { ...record, rhythmKmH: undefined }
+    const fields = {
+      ...fieldsFromRecord(recordNoRhythm),
+      durationHhmm: '01:00', // distância publicada (25 km) ÷ 1h = 25 km/h
+    }
+    // o ritmo que faltava entra no diff por não existir no publicado
+    expect(diffPayload(fields, recordNoRhythm)).toEqual({ rhythmKmH: 25 })
   })
 })

--- a/tests/unit/suggestion-form.test.ts
+++ b/tests/unit/suggestion-form.test.ts
@@ -3,6 +3,7 @@ import {
   diffPayload,
   emptyFields,
   fieldsFromRecord,
+  parseDurationToMinutes,
   payloadFromFields,
 } from '../../lib/suggestion-form'
 import type { GroupRecord } from '../../types/suggestion'
@@ -56,6 +57,58 @@ describe('payloadFromFields', () => {
   it('diff não acusa mudança quando o number do input é igual ao publicado', () => {
     const fields = { ...fieldsFromRecord(record), distanceKm: 25 }
     expect(diffPayload(fields, record)).toEqual({})
+  })
+
+  it('deriva o ritmo da duração quando o ritmo não é informado', () => {
+    const fields = {
+      ...emptyFields(),
+      name: 'Pedal Novo',
+      distanceKm: 50,
+      durationHhmm: '02:30',
+    }
+    expect(payloadFromFields(fields)).toEqual({
+      name: 'Pedal Novo',
+      distanceKm: 50,
+      rhythmKmH: 20,
+    })
+  })
+
+  it('o ritmo informado tem precedência e a duração não é persistida', () => {
+    const fields = {
+      ...emptyFields(),
+      name: 'Pedal Novo',
+      distanceKm: 50,
+      rhythmKmH: 18,
+      durationHhmm: '02:30',
+    }
+    expect(payloadFromFields(fields)).toEqual({
+      name: 'Pedal Novo',
+      distanceKm: 50,
+      rhythmKmH: 18,
+    })
+  })
+
+  it('ignora a duração quando não há distância', () => {
+    const fields = {
+      ...emptyFields(),
+      name: 'Pedal Novo',
+      durationHhmm: '02:30',
+    }
+    expect(payloadFromFields(fields)).toEqual({ name: 'Pedal Novo' })
+  })
+})
+
+describe('parseDurationToMinutes', () => {
+  it('converte "HH:MM" em minutos', () => {
+    expect(parseDurationToMinutes('02:30')).toBe(150)
+    expect(parseDurationToMinutes('00:45')).toBe(45)
+  })
+
+  it('retorna null para vazio, zero ou formato inválido', () => {
+    expect(parseDurationToMinutes('')).toBeNull()
+    expect(parseDurationToMinutes('00:00')).toBeNull()
+    expect(parseDurationToMinutes('9:99')).toBeNull()
+    expect(parseDurationToMinutes('abc')).toBeNull()
   })
 })
 

--- a/tests/unit/suggestion-schemas.test.ts
+++ b/tests/unit/suggestion-schemas.test.ts
@@ -98,6 +98,15 @@ describe('suggestionSchema', () => {
     expect(result.success).toBe(false)
   })
 
+  it('rejeita ritmo acima de 60 (backstop do ritmo derivado da duração)', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'CREATE',
+      payload: { ...validPayload, distanceKm: 60, rhythmKmH: 120 },
+      justification,
+    })
+    expect(result.success).toBe(false)
+  })
+
   it('rejeita justificativa curta demais', () => {
     const result = suggestionSchema.safeParse({
       type: 'CREATE',

--- a/tests/unit/time.test.ts
+++ b/tests/unit/time.test.ts
@@ -3,6 +3,7 @@ import {
   getPeriodFromHour,
   getRhythmCategory,
   getEstimatedLapDuration,
+  getRhythmFromDistanceAndDuration,
 } from '../../lib/time'
 
 describe('time helpers', () => {
@@ -38,5 +39,30 @@ describe('time helpers', () => {
     expect(getRhythmCategory(12)).toBe('light')
     expect(getRhythmCategory(18)).toBe('moderate')
     expect(getRhythmCategory(26)).toBe('strong')
+  })
+
+  it('deriva o ritmo a partir da distância e da duração', () => {
+    expect(
+      getRhythmFromDistanceAndDuration({
+        distanceKm: 50,
+        durationMinutes: 150,
+      }),
+    ).toBe(20)
+    // arredonda em 1 casa decimal (50 / 3h = 16,666…)
+    expect(
+      getRhythmFromDistanceAndDuration({
+        distanceKm: 50,
+        durationMinutes: 180,
+      }),
+    ).toBe(16.7)
+  })
+
+  it('retorna null quando distância ou duração não permitem o cálculo', () => {
+    expect(
+      getRhythmFromDistanceAndDuration({ distanceKm: 0, durationMinutes: 60 }),
+    ).toBeNull()
+    expect(
+      getRhythmFromDistanceAndDuration({ distanceKm: 50, durationMinutes: 0 }),
+    ).toBeNull()
   })
 })


### PR DESCRIPTION
Promove a `develop` para produção. **Mergear este PR dispara a release automática.**

## O que vai ao ar

### ✨ Duração do pedal no formulário (#92)
Quem não usa ciclocomputador agora pode informar **quanto tempo** o pedal dura, e
derivamos o **ritmo** (`distância ÷ duração`) — campo opcional HH:MM nos forms de
criar e corrigir grupo, com preview ao vivo. O ritmo digitado tem precedência; a
duração é só auxílio de input (não persistida). Passou por code review (reforços
de teste aplicados) e helper de UI com destaque verde theme-aware.

## O que acontece ao mergear (automático)

1. **Netlify publica a `main`** → a feature entra em produção.
2. O **release-please** abre a Release PR da **`v1.2.0`** (minor, por causa do
   `feat:`) e, com o `RELEASE_PLEASE_TOKEN` ligado, **auto-mergeia**.
3. Tag `v1.2.0` + GitHub Release + `CHANGELOG.md` + **back-merge** para a `develop`
   — tudo sem intervenção.

> Checks de CI/commitlint e o deploy preview já passaram no #92.
> `feat` → **minor**; nada de breaking.
