### PR TITLE
feat(suggestions): aviso no Discord a cada nova sugestão

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ GRAPHQL_TOKEN=
 TURNSTILE_ENABLED=false
 TURNSTILE_SECRET_KEY=
 NUXT_PUBLIC_TURNSTILE_SITE_KEY=
+
+# Webhook do Discord para avisar a cada nova sugestão (opcional — opt-in).
+# Crie em: canal → Editar → Integrações → Webhooks → Novo webhook → copiar URL.
+# Sem esta variável, o aviso fica desligado (o formulário funciona normalmente).
+DISCORD_WEBHOOK_URL=

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -57,8 +57,12 @@ copiar a URL) e defina `DISCORD_WEBHOOK_URL` no `.env` local e nas variáveis do
 sugestão dispara uma mensagem com tipo, grupo, justificativa e contato. Sem a variável, o aviso
 fica desligado (não quebra nada).
 
-> O aviso sai do próprio endpoint `POST /api/suggestions` em modo _fire-and-forget_: se o Discord
-> falhar, a sugestão ainda é registrada normalmente.
+> ⚠️ **Privacidade (LGPD):** a mensagem inclui o **e-mail de contato** e a **justificativa** do
+> colaborador — dados pessoais. Use um canal **privado**, restrito à curadoria, e trate a URL do
+> webhook como segredo (quem a tem consegue postar nesse canal).
+
+> O aviso sai do próprio endpoint `POST /api/suggestions` em modo _best-effort_ (com timeout
+> curto): se o Discord falhar ou demorar, a sugestão ainda é registrada normalmente.
 
 **Alternativa — webhook do Hygraph:** para notificar também entries criadas direto no Studio
 (fora do formulário), crie em **Project settings → Webhooks** um webhook em **Entry created** do

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -51,9 +51,18 @@ agendamento por vez — agendas múltiplas continuam sendo editadas direto no Hy
 
 ## 3. Notificação (opcional, recomendado)
 
-Em **Project settings → Webhooks**, crie um webhook disparado em **Entry created** do model
-`Suggestion` apontando para um serviço de notificação (ex.: Zapier/Make → e-mail, ou um webhook
-do Slack). Assim você fica sabendo de cada sugestão sem precisar abrir o Hygraph.
+O site já avisa **no Discord** a cada nova sugestão, sem depender do Studio. Crie um **webhook**
+num canal do Discord (canal → **Editar** → **Integrações** → **Webhooks** → **Novo webhook** →
+copiar a URL) e defina `DISCORD_WEBHOOK_URL` no `.env` local e nas variáveis do Netlify. Cada
+sugestão dispara uma mensagem com tipo, grupo, justificativa e contato. Sem a variável, o aviso
+fica desligado (não quebra nada).
+
+> O aviso sai do próprio endpoint `POST /api/suggestions` em modo _fire-and-forget_: se o Discord
+> falhar, a sugestão ainda é registrada normalmente.
+
+**Alternativa — webhook do Hygraph:** para notificar também entries criadas direto no Studio
+(fora do formulário), crie em **Project settings → Webhooks** um webhook em **Entry created** do
+model `Suggestion` apontando para um serviço (ex.: Zapier/Make → e-mail ou Slack).
 
 ## 4. Proteções ativas no site
 

--- a/lib/suggestion-notification.ts
+++ b/lib/suggestion-notification.ts
@@ -72,3 +72,33 @@ export function buildDiscordMessage(
     allowed_mentions: { parse: [] },
   }
 }
+
+/**
+ * Transporte do aviso: recebe a URL já resolvida e a mensagem pronta. Injetável
+ * para teste — o adaptador real (`server/utils/notify.ts`) usa `$fetch`.
+ */
+export type DiscordSender = (
+  url: string,
+  payload: DiscordWebhookPayload,
+) => Promise<unknown>
+
+/**
+ * Decide e envia o aviso de uma sugestão (best-effort, testável por injeção):
+ * no-op sem `webhookUrl`; do contrário envia a mensagem montada e **engole** o
+ * erro do transporte — o cadastro da sugestão nunca é derrubado pelo aviso.
+ */
+export async function sendSuggestionNotice(
+  webhookUrl: string | undefined,
+  notice: NewSuggestionNotice,
+  send: DiscordSender,
+): Promise<void> {
+  if (!webhookUrl) {
+    return
+  }
+  try {
+    await send(webhookUrl, buildDiscordMessage(notice))
+  } catch (error) {
+    // não relança: o usuário já teve a sugestão registrada com sucesso
+    console.warn('[suggestions] falha ao notificar no Discord:', error)
+  }
+}

--- a/lib/suggestion-notification.ts
+++ b/lib/suggestion-notification.ts
@@ -1,0 +1,74 @@
+import type {
+  SuggestionGroupPayload,
+  SuggestionType,
+} from '../types/suggestion'
+
+/** Dados de uma sugestão recém-criada, o suficiente para montar o aviso. */
+export type NewSuggestionNotice = {
+  id: string
+  type: SuggestionType
+  justification: string
+  targetId?: string
+  contactEmail?: string
+  payload?: SuggestionGroupPayload
+}
+
+/**
+ * Payload do webhook do Discord. `allowed_mentions.parse: []` neutraliza pings
+ * (@everyone/@here/usuários) que possam vir no texto livre de uma sugestão — o
+ * Zod tira HTML, mas não menções do Discord.
+ */
+export type DiscordWebhookPayload = {
+  content: string
+  allowed_mentions: { parse: string[] }
+}
+
+const TYPE_LABEL: Record<SuggestionType, string> = {
+  CREATE: 'novo grupo',
+  UPDATE: 'correção',
+  DELETE: 'remoção',
+}
+
+const DISCORD_CONTENT_LIMIT = 2000
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`
+}
+
+/** Campos preenchidos do payload — usado no resumo de um UPDATE. */
+function filledFields(payload: SuggestionGroupPayload): string[] {
+  return Object.entries(payload)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key]) => key)
+}
+
+/** Monta a mensagem do Discord a partir de uma sugestão recém-criada (puro). */
+export function buildDiscordMessage(
+  notice: NewSuggestionNotice,
+): DiscordWebhookPayload {
+  const lines = [`🚲 **Nova sugestão · ${TYPE_LABEL[notice.type]}**`]
+
+  if (notice.type === 'CREATE' && notice.payload?.name) {
+    lines.push(`**Grupo:** ${notice.payload.name}`)
+  } else if (notice.targetId) {
+    lines.push(`**Grupo alvo:** \`${notice.targetId}\``)
+  }
+
+  if (notice.type === 'UPDATE' && notice.payload) {
+    const fields = filledFields(notice.payload)
+    if (fields.length > 0) {
+      lines.push(`**Campos:** ${fields.join(', ')}`)
+    }
+  }
+
+  lines.push(`**Justificativa:** ${notice.justification}`)
+  if (notice.contactEmail) {
+    lines.push(`**Contato:** ${notice.contactEmail}`)
+  }
+  lines.push(`\`id: ${notice.id}\``)
+
+  return {
+    content: truncate(lines.join('\n'), DISCORD_CONTENT_LIMIT),
+    allowed_mentions: { parse: [] },
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -44,6 +44,7 @@ export default defineNuxtConfig({
     hygraphToken: process.env.GRAPHQL_TOKEN || '',
     turnstileSecretKey: process.env.TURNSTILE_SECRET_KEY || '',
     turnstileEnabled: process.env.TURNSTILE_ENABLED === 'true',
+    discordWebhookUrl: process.env.DISCORD_WEBHOOK_URL || '',
     public: {
       hygraphEndpoint:
         process.env.HYGRAPH_ENDPOINT ||

--- a/server/api/suggestions.post.ts
+++ b/server/api/suggestions.post.ts
@@ -100,7 +100,20 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    return await createSuggestion(body, hygraphRequest)
+    const result = await createSuggestion(body, hygraphRequest)
+
+    // aviso fire-and-forget no Discord (nunca derruba a requisição: a sugestão
+    // já foi registrada). No-op se DISCORD_WEBHOOK_URL não estiver configurado.
+    await notifyNewSuggestion({
+      id: result.id,
+      type: parsed.type,
+      justification: parsed.justification,
+      targetId: parsed.targetId,
+      contactEmail: parsed.contactEmail || undefined,
+      payload: parsed.payload,
+    })
+
+    return result
   } catch (error) {
     if (error instanceof SuggestionError) {
       throw createError({

--- a/server/api/suggestions.post.ts
+++ b/server/api/suggestions.post.ts
@@ -102,14 +102,15 @@ export default defineEventHandler(async (event) => {
 
     const result = await createSuggestion(body, hygraphRequest)
 
-    // aviso fire-and-forget no Discord (nunca derruba a requisição: a sugestão
-    // já foi registrada). No-op se DISCORD_WEBHOOK_URL não estiver configurado.
+    // aviso best-effort no Discord: awaitado (com timeout curto) para o serverless
+    // não congelar antes do POST, mas nunca derruba a resposta — a sugestão já foi
+    // registrada. No-op se DISCORD_WEBHOOK_URL não estiver configurado.
     await notifyNewSuggestion({
       id: result.id,
       type: parsed.type,
       justification: parsed.justification,
       targetId: parsed.targetId,
-      contactEmail: parsed.contactEmail || undefined,
+      contactEmail: parsed.contactEmail,
       payload: parsed.payload,
     })
 

--- a/server/utils/notify.ts
+++ b/server/utils/notify.ts
@@ -1,25 +1,26 @@
-import { buildDiscordMessage } from '../../lib/suggestion-notification'
+import { sendSuggestionNotice } from '../../lib/suggestion-notification'
 import type { NewSuggestionNotice } from '../../lib/suggestion-notification'
 
+// Timeout curto do POST ao Discord: o aviso é awaitado antes da resposta, então
+// um Discord lento/pendurado não pode segurar o envio do formulário do usuário.
+const DISCORD_TIMEOUT_MS = 3000
+
 /**
- * Avisa no Discord que chegou uma sugestão. Fire-and-forget seguro: nunca lança
- * — uma falha no aviso não pode derrubar o cadastro da sugestão. No-op quando
- * `DISCORD_WEBHOOK_URL` não está configurado (o recurso é opt-in).
+ * Avisa no Discord que chegou uma sugestão. Best-effort: nunca lança (uma falha
+ * no aviso não derruba o cadastro) e tem timeout curto para não atrasar a
+ * resposta. No-op quando `DISCORD_WEBHOOK_URL` não está configurado (opt-in).
  */
-export async function notifyNewSuggestion(
+export function notifyNewSuggestion(
   notice: NewSuggestionNotice,
 ): Promise<void> {
-  const webhookUrl = useRuntimeConfig().discordWebhookUrl
-  if (!webhookUrl) {
-    return
-  }
-  try {
-    await $fetch(webhookUrl, {
-      method: 'POST',
-      body: buildDiscordMessage(notice),
-    })
-  } catch (error) {
-    // não relança: o usuário já teve a sugestão registrada com sucesso
-    console.warn('[suggestions] falha ao notificar no Discord:', error)
-  }
+  return sendSuggestionNotice(
+    useRuntimeConfig().discordWebhookUrl,
+    notice,
+    (url, payload) =>
+      $fetch(url, {
+        method: 'POST',
+        body: payload,
+        timeout: DISCORD_TIMEOUT_MS,
+      }),
+  )
 }

--- a/server/utils/notify.ts
+++ b/server/utils/notify.ts
@@ -1,0 +1,25 @@
+import { buildDiscordMessage } from '../../lib/suggestion-notification'
+import type { NewSuggestionNotice } from '../../lib/suggestion-notification'
+
+/**
+ * Avisa no Discord que chegou uma sugestão. Fire-and-forget seguro: nunca lança
+ * — uma falha no aviso não pode derrubar o cadastro da sugestão. No-op quando
+ * `DISCORD_WEBHOOK_URL` não está configurado (o recurso é opt-in).
+ */
+export async function notifyNewSuggestion(
+  notice: NewSuggestionNotice,
+): Promise<void> {
+  const webhookUrl = useRuntimeConfig().discordWebhookUrl
+  if (!webhookUrl) {
+    return
+  }
+  try {
+    await $fetch(webhookUrl, {
+      method: 'POST',
+      body: buildDiscordMessage(notice),
+    })
+  } catch (error) {
+    // não relança: o usuário já teve a sugestão registrada com sucesso
+    console.warn('[suggestions] falha ao notificar no Discord:', error)
+  }
+}

--- a/tests/unit/suggestion-notification.test.ts
+++ b/tests/unit/suggestion-notification.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { buildDiscordMessage } from '../../lib/suggestion-notification'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildDiscordMessage,
+  sendSuggestionNotice,
+} from '../../lib/suggestion-notification'
 import type { NewSuggestionNotice } from '../../lib/suggestion-notification'
 
 const base: NewSuggestionNotice = {
@@ -50,6 +53,15 @@ describe('buildDiscordMessage', () => {
     expect(msg.content).not.toContain('Contato:')
   })
 
+  it('omite o contato quando é string vazia (não só ausente)', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      contactEmail: '',
+      payload: { name: 'X' },
+    })
+    expect(msg.content).not.toContain('Contato:')
+  })
+
   it('sempre neutraliza menções (anti @everyone injetado na justificativa)', () => {
     const msg = buildDiscordMessage({
       ...base,
@@ -65,5 +77,43 @@ describe('buildDiscordMessage', () => {
     })
     expect(msg.content.length).toBeLessThanOrEqual(2000)
     expect(msg.content.endsWith('…')).toBe(true)
+  })
+})
+
+describe('sendSuggestionNotice', () => {
+  const notice: NewSuggestionNotice = {
+    id: 'x1',
+    type: 'CREATE',
+    justification: 'oi',
+    payload: { name: 'Grupo G' },
+  }
+
+  it('no-op quando não há webhook URL (não chama o transporte)', async () => {
+    const send = vi.fn()
+    await sendSuggestionNotice('', notice, send)
+    await sendSuggestionNotice(undefined, notice, send)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('envia a mensagem montada para a URL configurada', async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    await sendSuggestionNotice('http://hook', notice, send)
+    expect(send).toHaveBeenCalledWith(
+      'http://hook',
+      expect.objectContaining({
+        content: expect.stringContaining('**Grupo:** Grupo G'),
+        allowed_mentions: { parse: [] },
+      }),
+    )
+  })
+
+  it('engole erro do transporte sem relançar (não derruba o cadastro)', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('discord fora do ar'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await expect(
+      sendSuggestionNotice('http://hook', notice, send),
+    ).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 })

--- a/tests/unit/suggestion-notification.test.ts
+++ b/tests/unit/suggestion-notification.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { buildDiscordMessage } from '../../lib/suggestion-notification'
+import type { NewSuggestionNotice } from '../../lib/suggestion-notification'
+
+const base: NewSuggestionNotice = {
+  id: 'abc123',
+  type: 'CREATE',
+  justification: 'grupo novo do meu bairro',
+}
+
+describe('buildDiscordMessage', () => {
+  it('CREATE: inclui nome do grupo, justificativa, contato e id', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      payload: { name: 'Pedal da Sé' },
+      contactEmail: 'foo@bar.com',
+    })
+    expect(msg.content).toContain('novo grupo')
+    expect(msg.content).toContain('**Grupo:** Pedal da Sé')
+    expect(msg.content).toContain('grupo novo do meu bairro')
+    expect(msg.content).toContain('**Contato:** foo@bar.com')
+    expect(msg.content).toContain('id: abc123')
+  })
+
+  it('UPDATE: mostra o alvo e os campos alterados', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      type: 'UPDATE',
+      targetId: 'grp1',
+      payload: { distanceKm: 50, startHour: '08:00' },
+    })
+    expect(msg.content).toContain('correção')
+    expect(msg.content).toContain('`grp1`')
+    expect(msg.content).toContain('**Campos:** distanceKm, startHour')
+  })
+
+  it('DELETE: mostra o alvo, sem listar campos', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      type: 'DELETE',
+      targetId: 'grp1',
+    })
+    expect(msg.content).toContain('remoção')
+    expect(msg.content).toContain('`grp1`')
+    expect(msg.content).not.toContain('Campos:')
+  })
+
+  it('omite o contato quando ausente', () => {
+    const msg = buildDiscordMessage({ ...base, payload: { name: 'X' } })
+    expect(msg.content).not.toContain('Contato:')
+  })
+
+  it('sempre neutraliza menções (anti @everyone injetado na justificativa)', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      justification: 'me marca @everyone agora',
+    })
+    expect(msg.allowed_mentions).toEqual({ parse: [] })
+  })
+
+  it('trunca o conteúdo acima do limite do Discord (2000)', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      justification: 'x'.repeat(2500),
+    })
+    expect(msg.content.length).toBeLessThanOrEqual(2000)
+    expect(msg.content.endsWith('…')).toBe(true)
+  })
+})


### PR DESCRIPTION
## O que muda

Adiciona um **aviso no Discord** a cada nova sugestão recebida pelo formulário. Toda sugestão — **CREATE** (novo grupo), **UPDATE** (correção) ou **DELETE** (remoção) — dispara uma mensagem num webhook do Discord, com tipo, grupo, campos alterados (no UPDATE), justificativa e contato.

## Como funciona

- O aviso sai do próprio `POST /api/suggestions`, logo após a `Suggestion` ser criada — caminho único pros três tipos, então cobre CREATE/UPDATE/DELETE de uma vez.
- **Fire-and-forget seguro:** `notifyNewSuggestion` nunca lança; se o Discord falhar, o cadastro da sugestão segue normal. É `await`ado (não solto) pra a Netlify Function não congelar antes do POST sair.
- **Opt-in:** sem `DISCORD_WEBHOOK_URL`, vira no-op — nada quebra.
- **Segurança:** `allowed_mentions: { parse: [] }` impede que um `@everyone`/menção injetado numa justificativa pingue o canal (o Zod tira HTML, mas não menção do Discord).

## Arquitetura

- `lib/suggestion-notification.ts` — `buildDiscordMessage()` **puro** (sem I/O, testado).
- `server/utils/notify.ts` — I/O fino (lê `runtimeConfig`, faz o POST), no padrão de `server/utils/hygraph.ts`.
- `server/api/suggestions.post.ts` — dispara o aviso após `createSuggestion`.
- `nuxt.config.ts` / `.env.example` — variável `DISCORD_WEBHOOK_URL`.

## Como ativar

1. Discord: canal → **Editar** → **Integrações** → **Webhooks** → **Novo webhook** → copiar URL.
2. Definir `DISCORD_WEBHOOK_URL` no `.env` local **e** nas env vars do Netlify.

## Validação

- `typecheck`, `lint` e **testes** (6 novos: CREATE/UPDATE/DELETE, omissão de contato, anti-menção e truncamento de 2000) — verdes.
- ⚠️ Ainda **não** testado contra um webhook real do Discord (depende da URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
