### PR TITLE
feat(schedules): várias agendas por grupo + fluxo de adicionar agenda

### DIFF
--- a/components/contribution/GroupCombobox.vue
+++ b/components/contribution/GroupCombobox.vue
@@ -16,12 +16,13 @@
         :aria-expanded="open"
         :aria-controls="`${uid}-listbox`"
         :aria-activedescendant="activeId"
+        :aria-describedby="`${uid}-hint`"
         :placeholder="pending ? 'Carregando grupos…' : placeholder"
         :disabled="pending"
         @input="onInput"
         @focus="open = true"
         @keydown="onKeydown"
-        @blur="open = false"
+        @blur="onBlur"
       />
       <span
         v-if="selectedKind"
@@ -162,6 +163,21 @@ function choose(index: number) {
 function chooseNew() {
   model.value = { kind: 'new', name: query.value.trim() }
   open.value = false
+}
+
+/** Ao sair do campo: fecha a lista e, se a pessoa digitou o nome EXATO de um
+ *  grupo sem selecioná-lo, assume esse grupo — evita o submit sem seleção. */
+function onBlur() {
+  open.value = false
+  if (model.value || !query.value.trim()) {
+    return
+  }
+  const q = normalize(query.value)
+  const match = props.groups.find((group) => normalize(group.name) === q)
+  if (match) {
+    model.value = { kind: 'existing', group: match }
+    query.value = match.name
+  }
 }
 
 /** Enter/clique na opção ativa: grupo existente ou a opção "criar novo". */

--- a/components/contribution/GroupCombobox.vue
+++ b/components/contribution/GroupCombobox.vue
@@ -1,0 +1,323 @@
+<template>
+  <div class="combobox">
+    <label class="ps-fieldlabel" :for="`${uid}-input`">Grupo *</label>
+
+    <div class="combobox__control">
+      <input
+        :id="`${uid}-input`"
+        ref="inputRef"
+        v-model="query"
+        class="ps-input combobox__input"
+        type="text"
+        role="combobox"
+        autocomplete="off"
+        spellcheck="false"
+        aria-autocomplete="list"
+        :aria-expanded="open"
+        :aria-controls="`${uid}-listbox`"
+        :aria-activedescendant="activeId"
+        :placeholder="pending ? 'Carregando grupos…' : placeholder"
+        :disabled="pending"
+        @input="onInput"
+        @focus="open = true"
+        @keydown="onKeydown"
+        @blur="open = false"
+      />
+      <span
+        v-if="selectedKind"
+        class="combobox__badge"
+        :class="`combobox__badge--${selectedKind}`"
+        aria-hidden="true"
+      >
+        <PsIcon
+          :name="selectedKind === 'existing' ? 'check' : 'plus'"
+          :size="13"
+        />
+        {{ selectedKind === 'existing' ? 'grupo existente' : 'grupo novo' }}
+      </span>
+    </div>
+
+    <ul
+      v-show="open"
+      :id="`${uid}-listbox`"
+      class="combobox__list"
+      role="listbox"
+      aria-label="Grupos"
+    >
+      <li
+        v-for="(group, index) in filtered"
+        :id="`${uid}-opt-${index}`"
+        :key="group.id"
+        class="combobox__opt"
+        :class="{ 'is-active': index === activeIndex }"
+        role="option"
+        :aria-selected="index === activeIndex"
+        @mousedown.prevent="choose(index)"
+        @mousemove="activeIndex = index"
+      >
+        <span class="combobox__opt-name">{{ group.name }}</span>
+        <span class="combobox__opt-meta">{{ scheduleCount(group) }}</span>
+      </li>
+
+      <li
+        :id="`${uid}-opt-new`"
+        class="combobox__opt combobox__opt--new"
+        :class="{ 'is-active': activeIndex === filtered.length }"
+        role="option"
+        :aria-selected="activeIndex === filtered.length"
+        @mousedown.prevent="chooseNew()"
+        @mousemove="activeIndex = filtered.length"
+      >
+        <PsIcon name="plus" :size="14" />
+        <span>
+          Criar
+          <strong v-if="query.trim()">“{{ query.trim() }}”</strong>
+          <template v-else>um grupo</template>
+          novo
+        </span>
+      </li>
+    </ul>
+
+    <p :id="`${uid}-hint`" class="combobox__hint">
+      Escolha o grupo da lista para não duplicar. Não achou? Crie um novo.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, useId, watch } from 'vue'
+import type { GroupSelection } from '../../lib/contribution'
+import type { Group } from '../../types/group'
+
+const props = withDefaults(
+  defineProps<{
+    groups: Group[]
+    pending?: boolean
+    placeholder?: string
+  }>(),
+  { pending: false, placeholder: 'Buscar grupo pelo nome…' },
+)
+
+const model = defineModel<GroupSelection | null>({ default: null })
+
+const uid = useId()
+const inputRef = ref<HTMLInputElement | null>(null)
+const query = ref('')
+const open = ref(false)
+const activeIndex = ref(0)
+
+function normalize(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim()
+}
+
+const filtered = computed(() => {
+  const q = normalize(query.value)
+  if (!q) {
+    return props.groups
+  }
+  return props.groups.filter((group) => normalize(group.name).includes(q))
+})
+
+/** id da opção ativa, para `aria-activedescendant` (a "nova" fica após a lista). */
+const activeId = computed<string | undefined>(() => {
+  if (activeIndex.value < 0 || !open.value) {
+    return undefined
+  }
+  return activeIndex.value < filtered.value.length
+    ? `${uid}-opt-${activeIndex.value}`
+    : `${uid}-opt-new`
+})
+
+const selectedKind = computed(() => model.value?.kind)
+
+function scheduleCount(group: Group): string {
+  const count = group.schedules.length
+  if (count === 0) {
+    return 'sem agenda'
+  }
+  return count === 1 ? '1 agenda' : `${count} agendas`
+}
+
+function onInput() {
+  open.value = true
+  // editar invalida a seleção anterior; o destaque volta para a primeira opção
+  model.value = null
+  activeIndex.value = 0
+}
+
+function choose(index: number) {
+  const group = filtered.value[index]
+  if (!group) {
+    return
+  }
+  model.value = { kind: 'existing', group }
+  query.value = group.name
+  open.value = false
+}
+
+function chooseNew() {
+  model.value = { kind: 'new', name: query.value.trim() }
+  open.value = false
+}
+
+/** Enter/clique na opção ativa: grupo existente ou a opção "criar novo". */
+function selectActive() {
+  if (activeIndex.value < filtered.value.length) {
+    choose(activeIndex.value)
+  } else {
+    chooseNew()
+  }
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    if (!open.value) {
+      open.value = true
+      activeIndex.value = 0
+      return
+    }
+    activeIndex.value = Math.min(activeIndex.value + 1, filtered.value.length)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    if (!open.value) {
+      open.value = true
+    }
+    activeIndex.value = Math.max(activeIndex.value - 1, 0)
+  } else if (event.key === 'Enter') {
+    if (open.value && activeIndex.value >= 0) {
+      event.preventDefault()
+      selectActive()
+    }
+  } else if (event.key === 'Escape') {
+    if (open.value) {
+      event.preventDefault()
+      open.value = false
+    }
+  }
+}
+
+// pré-seleção externa (ex.: ?group=slug): reflete o nome do grupo no input
+watch(
+  model,
+  (selection) => {
+    if (
+      selection?.kind === 'existing' &&
+      query.value !== selection.group.name
+    ) {
+      query.value = selection.group.name
+    }
+  },
+  { immediate: true },
+)
+
+// mantém a opção ativa visível ao navegar pelo teclado
+watch(activeIndex, () => {
+  if (!open.value) {
+    return
+  }
+  nextTick(() => {
+    const id = activeId.value
+    if (id) {
+      document.getElementById(id)?.scrollIntoView({ block: 'nearest' })
+    }
+  })
+})
+</script>
+
+<style scoped>
+.combobox {
+  position: relative;
+  display: grid;
+  gap: var(--space-1);
+}
+
+.combobox__control {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.combobox__input {
+  flex: 1;
+}
+
+.combobox__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding: 2px var(--space-2);
+  border: 2px solid var(--color-border);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.combobox__badge--existing {
+  border-color: var(--color-bike-green);
+  color: var(--color-green-dark);
+}
+
+.combobox__badge--new {
+  border-color: var(--color-asphalt);
+  color: var(--color-asphalt);
+}
+
+.combobox__list {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% - var(--space-1));
+  left: 0;
+  right: 0;
+  max-height: 16rem;
+  margin: var(--space-1) 0 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  background: var(--color-paper);
+  border: 2px solid var(--color-asphalt);
+  box-shadow: var(--shadow-panel);
+}
+
+.combobox__opt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+}
+
+.combobox__opt.is-active {
+  background: var(--color-concrete);
+}
+
+.combobox__opt-name {
+  font-weight: 600;
+}
+
+.combobox__opt-meta {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  color: var(--color-asphalt-55);
+}
+
+.combobox__opt--new {
+  gap: var(--space-2);
+  justify-content: flex-start;
+  border-top: 2px solid var(--color-border);
+  font-weight: 600;
+}
+
+.combobox__hint {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-asphalt-55);
+}
+</style>

--- a/components/contribution/ScheduleFields.vue
+++ b/components/contribution/ScheduleFields.vue
@@ -1,0 +1,221 @@
+<template>
+  <fieldset class="schedule-fields">
+    <legend class="ps-label schedule-legend">{{ legend }}</legend>
+
+    <div class="ps-field-group">
+      <label class="ps-fieldlabel" :for="`${uid}-day`"
+        >Dia do pedal {{ required ? '*' : '' }}</label
+      >
+      <input
+        :id="`${uid}-day`"
+        v-model="model.day"
+        class="ps-input"
+        type="text"
+        maxlength="40"
+        placeholder="Ex.: Sábado"
+        :required="required"
+      />
+    </div>
+
+    <div class="ps-field-group">
+      <label class="ps-fieldlabel" :for="`${uid}-hour`"
+        >Horário de saída {{ required ? '*' : '' }}</label
+      >
+      <input
+        :id="`${uid}-hour`"
+        v-model="model.startHour"
+        class="ps-input"
+        type="time"
+        :required="required"
+      />
+    </div>
+
+    <div class="ps-field-group">
+      <label class="ps-fieldlabel" :for="`${uid}-effort`"
+        >Nível {{ required ? '*' : '' }}</label
+      >
+      <input
+        :id="`${uid}-effort`"
+        v-model="model.effort"
+        class="ps-input"
+        type="text"
+        maxlength="40"
+        placeholder="Ex.: Iniciante"
+        :required="required"
+      />
+    </div>
+
+    <div class="ps-field-group">
+      <label class="ps-fieldlabel" :for="`${uid}-distance`"
+        >Distância (km) {{ required ? '*' : '' }}</label
+      >
+      <input
+        :id="`${uid}-distance`"
+        v-model="model.distanceKm"
+        class="ps-input"
+        type="number"
+        min="1"
+        max="600"
+        step="any"
+        :required="required"
+      />
+    </div>
+
+    <div class="ps-field-group">
+      <label class="ps-fieldlabel" :for="`${uid}-rhythm`"
+        >Ritmo médio (km/h)</label
+      >
+      <input
+        :id="`${uid}-rhythm`"
+        v-model="model.rhythmKmH"
+        class="ps-input"
+        type="number"
+        min="1"
+        max="60"
+        step="any"
+      />
+    </div>
+
+    <div class="ps-field-group schedule-span">
+      <label class="ps-fieldlabel" :for="`${uid}-duration`"
+        >Duração aproximada (HH:MM)</label
+      >
+      <input
+        :id="`${uid}-duration`"
+        v-model="model.durationHhmm"
+        class="ps-input schedule-duration-input"
+        type="time"
+        :aria-describedby="`${uid}-duration-hint`"
+      />
+      <p
+        :id="`${uid}-duration-hint`"
+        class="schedule-duration-hint"
+        :class="`schedule-duration-hint--${durationHintTone}`"
+        aria-live="polite"
+      >
+        <template v-if="rhythmTyped">Usando o ritmo informado acima.</template>
+        <template v-else-if="derivedRhythm === null">
+          Não sabe o ritmo? Informe a duração e calculamos pela distância.
+        </template>
+        <template v-else-if="rhythmTooHigh">
+          Ritmo calculado (≈ {{ formatRhythm(derivedRhythm) }} km/h) parece alto
+          demais — confira a distância e a duração.
+        </template>
+        <template v-else>
+          Ritmo calculado: ≈ {{ formatRhythm(derivedRhythm) }} km/h.
+        </template>
+      </p>
+    </div>
+  </fieldset>
+</template>
+
+<script setup lang="ts">
+import { computed, useId } from 'vue'
+import { parseDurationToMinutes, parseNumber } from '../../lib/suggestion-form'
+import type { SuggestionFormFields } from '../../lib/suggestion-form'
+import { getRhythmFromDistanceAndDuration } from '../../lib/time'
+
+withDefaults(
+  defineProps<{
+    /** Marca dia/horário/nível/distância como obrigatórios (fluxo "adicionar agenda"). */
+    required?: boolean
+    legend?: string
+  }>(),
+  { required: false, legend: 'Agenda' },
+)
+
+const model = defineModel<SuggestionFormFields>({ required: true })
+const uid = useId()
+
+// o ritmo digitado tem precedência sobre a duração
+const rhythmTyped = computed(
+  () => parseNumber(model.value.rhythmKmH) !== undefined,
+)
+
+/** Ritmo derivado da distância + duração — só quando o ritmo não foi digitado. */
+const derivedRhythm = computed<number | null>(() => {
+  if (rhythmTyped.value) {
+    return null
+  }
+  const distanceKm = parseNumber(model.value.distanceKm)
+  const durationMinutes = parseDurationToMinutes(model.value.durationHhmm)
+  if (distanceKm === undefined || durationMinutes === null) {
+    return null
+  }
+  return getRhythmFromDistanceAndDuration({ distanceKm, durationMinutes })
+})
+
+// avisamos antes de enviar; este limite precisa acompanhar o `.max(60)` do
+// `rhythmKmH` em payloadSchema (lib/suggestion-schemas.ts), que é o backstop real
+const rhythmTooHigh = computed(
+  () => derivedRhythm.value !== null && derivedRhythm.value > 60,
+)
+
+// destaque (verde) no convite e no resultado; vermelho no aviso; discreto quando
+// o ritmo já foi digitado e a duração é ignorada
+const durationHintTone = computed(() => {
+  if (rhythmTooHigh.value) {
+    return 'warn'
+  }
+  if (rhythmTyped.value) {
+    return 'muted'
+  }
+  return 'accent'
+})
+
+function formatRhythm(value: number | null): string {
+  return value === null ? '' : String(value).replace('.', ',')
+}
+</script>
+
+<style scoped>
+.schedule-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.schedule-legend {
+  margin-bottom: var(--space-2);
+  padding: 0;
+}
+
+.schedule-span {
+  grid-column: 1 / -1;
+}
+
+.schedule-duration-input {
+  max-width: 12rem;
+}
+
+/* helper da duração: mais presente que os hints comuns, para a pessoa perceber
+   que pode preencher o ritmo pela duração */
+.schedule-duration-hint {
+  margin: var(--space-1) 0 0;
+  font-size: var(--text-base);
+}
+
+.schedule-duration-hint--accent {
+  color: var(--color-green-dark);
+  font-weight: 600;
+}
+
+.schedule-duration-hint--warn {
+  color: var(--color-alert-red);
+  font-weight: 600;
+}
+
+.schedule-duration-hint--muted {
+  font-size: var(--text-sm);
+  color: var(--color-asphalt-55);
+}
+
+@media (max-width: 560px) {
+  .schedule-fields {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/components/contribution/SuggestionDeleteForm.vue
+++ b/components/contribution/SuggestionDeleteForm.vue
@@ -22,14 +22,48 @@
       <p class="ps-label">Grupo</p>
       <p class="ps-data">{{ record.name }}</p>
       <p v-if="record.address" class="ps-body">{{ record.address }}</p>
-      <p v-if="record.day || record.startHour" class="ps-body">
-        {{ [record.day, record.startHour].filter(Boolean).join(' · ') }}
-      </p>
+      <ul v-if="record.schedules.length" class="suggestion-summary__agendas">
+        <li v-for="(sched, index) in record.schedules" :key="sched.id">
+          {{ scheduleLabel(sched, index) }}
+        </li>
+      </ul>
     </div>
 
+    <fieldset v-if="record.schedules.length > 1" class="removal-scope">
+      <legend class="ps-label removal-scope__legend">O que remover?</legend>
+      <label
+        class="removal-scope__opt"
+        :class="{ 'is-active': selectedTarget === 'group' }"
+      >
+        <input
+          type="radio"
+          name="removal-scope"
+          value="group"
+          :checked="selectedTarget === 'group'"
+          @change="selectedTarget = 'group'"
+        />
+        <span>O grupo inteiro (todas as agendas)</span>
+      </label>
+      <label
+        v-for="(sched, index) in record.schedules"
+        :key="sched.id"
+        class="removal-scope__opt"
+        :class="{ 'is-active': selectedTarget === sched.id }"
+      >
+        <input
+          type="radio"
+          name="removal-scope"
+          :value="sched.id"
+          :checked="selectedTarget === sched.id"
+          @change="selectedTarget = sched.id"
+        />
+        <span>Só a agenda: {{ scheduleLabel(sched, index) }}</span>
+      </label>
+    </fieldset>
+
     <p class="ps-body suggestion-intro">
-      O pedido de remoção passa por revisão antes de qualquer mudança. Se você é
-      quem organiza o pedal e não quer o grupo exposto no site, conte isso na
+      O pedido passa por revisão antes de qualquer mudança. Se você é quem
+      organiza o pedal e não quer o grupo exposto no site, conte isso na
       justificativa — esse pedido tem prioridade.
     </p>
 
@@ -43,7 +77,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { scheduleLabel } from '../../lib/suggestion-form'
 import type { SuggestionRequest } from '../../types/suggestion'
 import SuggestionFormBase from './SuggestionFormBase.vue'
 
@@ -68,6 +103,12 @@ const loadFailed = computed(
   () => Boolean(error.value) && error.value?.statusCode !== 404,
 )
 
+// "group" = remover o grupo inteiro; um id = remover só aquela agenda
+const selectedTarget = ref('group')
+watch(record, () => {
+  selectedTarget.value = 'group'
+})
+
 function buildRequest(common: {
   justification: string
   contactEmail: string
@@ -78,9 +119,15 @@ function buildRequest(common: {
     return { error: 'Grupo não carregado. Recarregue a página.' }
   }
 
+  const payload =
+    selectedTarget.value !== 'group'
+      ? { scheduleId: selectedTarget.value }
+      : undefined
+
   return {
     type: 'DELETE',
     targetId: record.value.id,
+    payload,
     ...common,
   }
 }
@@ -98,6 +145,45 @@ function buildRequest(common: {
 
 .suggestion-summary p {
   margin: 0;
+}
+
+.suggestion-summary__agendas {
+  margin: var(--space-1) 0 0;
+  padding-left: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-asphalt-55);
+}
+
+.removal-scope {
+  display: grid;
+  gap: var(--space-2);
+  max-width: 560px;
+  margin: 0 0 var(--space-5);
+  padding: var(--space-4);
+  border: 2px solid var(--color-border);
+}
+
+.removal-scope__legend {
+  padding: 0 var(--space-2);
+}
+
+.removal-scope__opt {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 2px solid var(--color-border);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+.removal-scope__opt:hover {
+  border-color: var(--color-asphalt);
+}
+
+.removal-scope__opt.is-active {
+  border-color: var(--color-alert-red);
 }
 
 .suggestion-intro {

--- a/components/contribution/SuggestionGroupFields.vue
+++ b/components/contribution/SuggestionGroupFields.vue
@@ -43,101 +43,6 @@
       />
     </div>
 
-    <div class="ps-field-group">
-      <label class="ps-fieldlabel" :for="`${uid}-day`">Dia do pedal</label>
-      <input
-        :id="`${uid}-day`"
-        v-model="model.day"
-        class="ps-input"
-        type="text"
-        maxlength="40"
-        placeholder="Ex.: Sábado"
-      />
-    </div>
-
-    <div class="ps-field-group">
-      <label class="ps-fieldlabel" :for="`${uid}-hour`">Horário de saída</label>
-      <input
-        :id="`${uid}-hour`"
-        v-model="model.startHour"
-        class="ps-input"
-        type="time"
-      />
-    </div>
-
-    <div class="ps-field-group">
-      <label class="ps-fieldlabel" :for="`${uid}-effort`">Nível</label>
-      <input
-        :id="`${uid}-effort`"
-        v-model="model.effort"
-        class="ps-input"
-        type="text"
-        maxlength="40"
-        placeholder="Ex.: Iniciante"
-      />
-    </div>
-
-    <div class="ps-field-group">
-      <label class="ps-fieldlabel" :for="`${uid}-distance`"
-        >Distância (km)</label
-      >
-      <input
-        :id="`${uid}-distance`"
-        v-model="model.distanceKm"
-        class="ps-input"
-        type="number"
-        min="1"
-        max="600"
-        step="any"
-      />
-    </div>
-
-    <div class="ps-field-group">
-      <label class="ps-fieldlabel" :for="`${uid}-rhythm`"
-        >Ritmo médio (km/h)</label
-      >
-      <input
-        :id="`${uid}-rhythm`"
-        v-model="model.rhythmKmH"
-        class="ps-input"
-        type="number"
-        min="1"
-        max="60"
-        step="any"
-      />
-    </div>
-
-    <div class="ps-field-group suggestion-span">
-      <label class="ps-fieldlabel" :for="`${uid}-duration`"
-        >Duração aproximada (HH:MM)</label
-      >
-      <input
-        :id="`${uid}-duration`"
-        v-model="model.durationHhmm"
-        class="ps-input suggestion-duration-input"
-        type="time"
-        :aria-describedby="`${uid}-duration-hint`"
-      />
-      <p
-        :id="`${uid}-duration-hint`"
-        class="suggestion-duration-hint"
-        :class="`suggestion-duration-hint--${durationHintTone}`"
-        aria-live="polite"
-      >
-        <template v-if="rhythmTyped">Usando o ritmo informado acima.</template>
-        <template v-else-if="derivedRhythm === null">
-          Não sabe o ritmo? Informe a duração e calculamos pela distância.
-        </template>
-        <template v-else-if="rhythmTooHigh">
-          Ritmo calculado (≈ {{ formatRhythm(derivedRhythm) }} km/h) parece alto
-          demais — confira a distância e a duração.
-        </template>
-        <template v-else>
-          Ritmo calculado: ≈ {{ formatRhythm(derivedRhythm) }} km/h.
-        </template>
-      </p>
-    </div>
-
     <div class="ps-field-group suggestion-span">
       <span :id="`${uid}-point`" class="ps-fieldlabel">
         Ponto de saída no mapa {{ required ? '*' : '' }}
@@ -198,14 +103,18 @@
       </details>
     </div>
   </fieldset>
+
+  <!-- agenda (GroupInfo) — opcional ao criar grupo; o mesmo componente é
+       reusado, obrigatório, no fluxo "adicionar agenda" -->
+  <ScheduleFields v-model="model" />
 </template>
 
 <script setup lang="ts">
 import { computed, useId } from 'vue'
-import { parseDurationToMinutes, parseNumber } from '../../lib/suggestion-form'
+import { parseNumber } from '../../lib/suggestion-form'
 import type { SuggestionFormFields } from '../../lib/suggestion-form'
-import { getRhythmFromDistanceAndDuration } from '../../lib/time'
 import LocationPicker from './LocationPicker.client.vue'
+import ScheduleFields from './ScheduleFields.vue'
 
 withDefaults(
   defineProps<{
@@ -223,46 +132,6 @@ const hasPoint = computed(
     parseNumber(model.value.latitude) !== undefined &&
     parseNumber(model.value.longitude) !== undefined,
 )
-
-// o ritmo digitado tem precedência sobre a duração
-const rhythmTyped = computed(
-  () => parseNumber(model.value.rhythmKmH) !== undefined,
-)
-
-/** Ritmo derivado da distância + duração — só quando o ritmo não foi digitado. */
-const derivedRhythm = computed<number | null>(() => {
-  if (rhythmTyped.value) {
-    return null
-  }
-  const distanceKm = parseNumber(model.value.distanceKm)
-  const durationMinutes = parseDurationToMinutes(model.value.durationHhmm)
-  if (distanceKm === undefined || durationMinutes === null) {
-    return null
-  }
-  return getRhythmFromDistanceAndDuration({ distanceKm, durationMinutes })
-})
-
-// avisamos antes de enviar; este limite precisa acompanhar o `.max(60)` do
-// `rhythmKmH` em payloadSchema (lib/suggestion-schemas.ts), que é o backstop real
-const rhythmTooHigh = computed(
-  () => derivedRhythm.value !== null && derivedRhythm.value > 60,
-)
-
-// destaque (verde) no convite e no resultado; vermelho no aviso; discreto quando
-// o ritmo já foi digitado e a duração é ignorada
-const durationHintTone = computed(() => {
-  if (rhythmTooHigh.value) {
-    return 'warn'
-  }
-  if (rhythmTyped.value) {
-    return 'muted'
-  }
-  return 'accent'
-})
-
-function formatRhythm(value: number | null): string {
-  return value === null ? '' : String(value).replace('.', ',')
-}
 </script>
 
 <style scoped>
@@ -287,32 +156,6 @@ function formatRhythm(value: number | null): string {
 .suggestion-hint {
   margin: 0;
   font-size: var(--text-xs);
-  color: var(--color-asphalt-55);
-}
-
-.suggestion-duration-input {
-  max-width: 12rem;
-}
-
-/* helper da duração: mais presente que os hints comuns, para a pessoa perceber
-   que pode preencher o ritmo pela duração */
-.suggestion-duration-hint {
-  margin: var(--space-1) 0 0;
-  font-size: var(--text-base);
-}
-
-.suggestion-duration-hint--accent {
-  color: var(--color-green-dark);
-  font-weight: 600;
-}
-
-.suggestion-duration-hint--warn {
-  color: var(--color-alert-red);
-  font-weight: 600;
-}
-
-.suggestion-duration-hint--muted {
-  font-size: var(--text-sm);
   color: var(--color-asphalt-55);
 }
 
@@ -342,12 +185,6 @@ function formatRhythm(value: number | null): string {
 
 @media (max-width: 560px) {
   .suggestion-coords-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 560px) {
-  .suggestion-fields {
     grid-template-columns: 1fr;
   }
 }

--- a/components/contribution/SuggestionScheduleForm.vue
+++ b/components/contribution/SuggestionScheduleForm.vue
@@ -52,7 +52,7 @@ const fields = ref<SuggestionFormFields>(emptyFields())
 
 // pré-seleção via ?group=slug, assim que a lista de grupos carrega
 watch(
-  () => [props.groups, props.preselectSlug] as const,
+  [() => props.groups, () => props.preselectSlug],
   ([groups, slug]) => {
     if (!slug || selection.value) {
       return

--- a/components/contribution/SuggestionScheduleForm.vue
+++ b/components/contribution/SuggestionScheduleForm.vue
@@ -1,0 +1,135 @@
+<template>
+  <SuggestionFormBase
+    submit-label="Enviar agenda"
+    justification-label="Sobre a agenda"
+    justification-hint="Conte como conhece o grupo e de onde vêm o dia e o horário."
+    :build-request="buildRequest"
+  >
+    <GroupCombobox v-model="selection" :groups="groups" :pending="pending" />
+
+    <template v-if="selection?.kind === 'existing'">
+      <ScheduleFields v-model="fields" required />
+    </template>
+
+    <template v-else-if="selection?.kind === 'new'">
+      <p class="schedule-newnote ps-body">
+        Grupo novo — preencha também o ponto de saída e o contato. Tudo passa
+        por revisão antes de ir ao ar.
+      </p>
+      <SuggestionGroupFields v-model="fields" required />
+    </template>
+  </SuggestionFormBase>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { GroupSelection } from '../../lib/contribution'
+import {
+  emptyFields,
+  hasCompleteSchedule,
+  payloadFromFields,
+} from '../../lib/suggestion-form'
+import type { SuggestionFormFields } from '../../lib/suggestion-form'
+import type { Group } from '../../types/group'
+import type { SuggestionRequest } from '../../types/suggestion'
+import GroupCombobox from './GroupCombobox.vue'
+import ScheduleFields from './ScheduleFields.vue'
+import SuggestionFormBase from './SuggestionFormBase.vue'
+import SuggestionGroupFields from './SuggestionGroupFields.vue'
+
+const props = withDefaults(
+  defineProps<{
+    groups: Group[]
+    pending?: boolean
+    /** Slug vindo de `?group=` para pré-selecionar o grupo (deep-link). */
+    preselectSlug?: string
+  }>(),
+  { pending: false, preselectSlug: undefined },
+)
+
+const selection = ref<GroupSelection | null>(null)
+const fields = ref<SuggestionFormFields>(emptyFields())
+
+// pré-seleção via ?group=slug, assim que a lista de grupos carrega
+watch(
+  () => [props.groups, props.preselectSlug] as const,
+  ([groups, slug]) => {
+    if (!slug || selection.value) {
+      return
+    }
+    const match = groups.find((group) => group.slug === slug)
+    if (match) {
+      selection.value = { kind: 'existing', group: match }
+    }
+  },
+  { immediate: true },
+)
+
+// ao escolher "criar grupo novo", leva o nome digitado para o campo do grupo
+watch(selection, (sel) => {
+  if (sel?.kind === 'new' && !fields.value.name.trim()) {
+    fields.value.name = sel.name
+  }
+})
+
+type CommonFields = {
+  justification: string
+  contactEmail: string
+  turnstileToken: string
+  website: string
+}
+
+function buildRequest(
+  common: CommonFields,
+): SuggestionRequest | { error: string } {
+  const sel = selection.value
+  if (!sel) {
+    return { error: 'Escolha um grupo da lista ou crie um novo.' }
+  }
+
+  if (sel.kind === 'existing') {
+    // só os campos de agenda — o grupo (nome/ponto/contato) já existe
+    const scheduleOnly: SuggestionFormFields = {
+      ...emptyFields(),
+      day: fields.value.day,
+      startHour: fields.value.startHour,
+      effort: fields.value.effort,
+      distanceKm: fields.value.distanceKm,
+      rhythmKmH: fields.value.rhythmKmH,
+      durationHhmm: fields.value.durationHhmm,
+    }
+    const payload = payloadFromFields(scheduleOnly)
+    if (!hasCompleteSchedule(payload)) {
+      return {
+        error:
+          'Preencha a agenda: dia, horário, nível, distância e o ritmo (ou a duração).',
+      }
+    }
+    return { type: 'CREATE', targetId: sel.group.id, payload, ...common }
+  }
+
+  // grupo novo: mesmo contrato do fluxo de criar grupo (grupo + agenda opcional)
+  const payload = payloadFromFields(fields.value)
+  if (
+    !payload.name ||
+    payload.latitude === undefined ||
+    payload.longitude === undefined
+  ) {
+    return {
+      error:
+        'Preencha pelo menos o nome do grupo e as coordenadas do ponto de saída.',
+    }
+  }
+  return { type: 'CREATE', payload, ...common }
+}
+</script>
+
+<style scoped>
+.schedule-newnote {
+  margin: 0;
+  padding: var(--space-3);
+  border-left: 4px solid var(--color-sign-yellow);
+  background: var(--color-paper-2);
+  font-size: var(--text-sm);
+}
+</style>

--- a/components/contribution/SuggestionUpdateForm.vue
+++ b/components/contribution/SuggestionUpdateForm.vue
@@ -25,6 +25,34 @@
       mudou.
     </p>
 
+    <fieldset v-if="record.schedules.length > 1" class="schedule-picker">
+      <legend class="ps-label schedule-picker__legend">
+        Qual agenda corrigir?
+      </legend>
+      <p class="schedule-picker__hint">
+        Este grupo tem {{ record.schedules.length }} agendas — escolha qual você
+        quer corrigir.
+      </p>
+      <div class="schedule-picker__opts">
+        <label
+          v-for="(sched, index) in record.schedules"
+          :key="sched.id"
+          class="schedule-picker__opt"
+          :class="{ 'is-active': sched.id === selectedScheduleId }"
+        >
+          <input
+            class="schedule-picker__radio"
+            type="radio"
+            name="schedule-pick"
+            :value="sched.id"
+            :checked="sched.id === selectedScheduleId"
+            @change="selectedScheduleId = sched.id"
+          />
+          <span>{{ scheduleLabel(sched, index) }}</span>
+        </label>
+      </div>
+    </fieldset>
+
     <SuggestionFormBase
       submit-label="Enviar correção"
       justification-hint="Conte de onde veio a informação corrigida (ex.: sou do grupo, o ponto mudou)."
@@ -48,8 +76,12 @@ import {
   diffPayload,
   emptyFields,
   fieldsFromRecord,
+  scheduleLabel,
 } from '../../lib/suggestion-form'
-import type { SuggestionRequest } from '../../types/suggestion'
+import type {
+  SuggestionGroupPayload,
+  SuggestionRequest,
+} from '../../types/suggestion'
 import SuggestionFormBase from './SuggestionFormBase.vue'
 import SuggestionGroupFields from './SuggestionGroupFields.vue'
 
@@ -76,15 +108,40 @@ const loadFailed = computed(
 )
 
 const fields = ref(emptyFields())
+const selectedScheduleId = ref<string>()
+
+const chosenSchedule = computed(() =>
+  record.value?.schedules.find((s) => s.id === selectedScheduleId.value),
+)
+
+// na carga do grupo: seleciona a 1ª agenda e pré-preenche
 watch(
   record,
   (value) => {
-    if (value) {
-      fields.value = fieldsFromRecord(value)
-    }
+    selectedScheduleId.value = value?.schedules[0]?.id
+    fields.value = value
+      ? fieldsFromRecord(value, value.schedules[0])
+      : emptyFields()
   },
   { immediate: true },
 )
+
+// trocar de agenda repreenche os campos com os valores publicados dela
+watch(selectedScheduleId, () => {
+  if (record.value) {
+    fields.value = fieldsFromRecord(record.value, chosenSchedule.value)
+  }
+})
+
+function hasScheduleChange(payload: SuggestionGroupPayload): boolean {
+  return (
+    payload.day !== undefined ||
+    payload.startHour !== undefined ||
+    payload.effort !== undefined ||
+    payload.distanceKm !== undefined ||
+    payload.rhythmKmH !== undefined
+  )
+}
 
 function buildRequest(common: {
   justification: string
@@ -96,12 +153,17 @@ function buildRequest(common: {
     return { error: 'Grupo não carregado. Recarregue a página.' }
   }
 
-  const payload = diffPayload(fields.value, record.value)
+  const payload = diffPayload(fields.value, record.value, chosenSchedule.value)
   if (Object.keys(payload).length === 0) {
     return {
       error:
         'Nenhum campo foi alterado. Mude o que precisa corrigir antes de enviar.',
     }
+  }
+
+  // marca a agenda alvo só quando um campo de agenda mudou
+  if (chosenSchedule.value && hasScheduleChange(payload)) {
+    payload.scheduleId = chosenSchedule.value.id
   }
 
   return {
@@ -117,6 +179,50 @@ function buildRequest(common: {
 .suggestion-intro {
   max-width: 560px;
   margin-bottom: var(--space-5);
+}
+
+.schedule-picker {
+  max-width: 560px;
+  margin: 0 0 var(--space-5);
+  padding: var(--space-4);
+  border: 2px solid var(--color-border);
+}
+
+.schedule-picker__legend {
+  padding: 0 var(--space-2);
+}
+
+.schedule-picker__hint {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-asphalt-55);
+}
+
+.schedule-picker__opts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.schedule-picker__opt {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 2px solid var(--color-border);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+.schedule-picker__opt:hover {
+  border-color: var(--color-asphalt);
+}
+
+.schedule-picker__opt.is-active {
+  border-color: var(--color-bike-green);
+  background: var(--color-green-tint);
 }
 
 .suggestion-notfound {

--- a/components/explore/GroupQuickView.vue
+++ b/components/explore/GroupQuickView.vue
@@ -19,6 +19,10 @@
           {{ group.departureAddress || 'Ponto de saída no mapa' }}
         </p>
         <GroupMetaBadges v-if="primarySchedule" :schedule="primarySchedule" />
+        <p v-if="extraSchedules > 0" class="qv__more">
+          +{{ extraSchedules }} {{ extraSchedules > 1 ? 'agendas' : 'agenda' }}
+          neste grupo
+        </p>
         <p v-if="duration" class="qv__dur">
           <PsIcon name="compass" :size="16" /> Tempo médio da volta:
           <strong>{{ duration }}</strong>
@@ -86,6 +90,9 @@ watch(
 )
 
 const primarySchedule = computed(() => props.group?.schedules[0])
+const extraSchedules = computed(() =>
+  props.group ? Math.max(props.group.schedules.length - 1, 0) : 0,
+)
 const duration = computed(() =>
   primarySchedule.value
     ? getEstimatedLapDuration({
@@ -158,6 +165,13 @@ const duration = computed(() =>
 }
 
 .qv__loc {
+  color: var(--color-asphalt-55);
+}
+
+.qv__more {
+  margin: 0;
+  font-size: var(--text-xs);
+  font-weight: 700;
   color: var(--color-asphalt-55);
 }
 

--- a/components/group/GroupCard.vue
+++ b/components/group/GroupCard.vue
@@ -17,6 +17,9 @@
         {{ group.departureAddress || 'Ponto de saída no mapa' }}
       </span>
       <GroupMetaBadges v-if="primarySchedule" :schedule="primarySchedule" />
+      <span v-if="extraSchedules > 0" class="ps-card__more">
+        +{{ extraSchedules }} {{ extraSchedules > 1 ? 'agendas' : 'agenda' }}
+      </span>
     </span>
   </button>
 </template>
@@ -36,6 +39,9 @@ defineEmits<{
 }>()
 
 const primarySchedule = computed(() => props.group.schedules[0])
+const extraSchedules = computed(() =>
+  Math.max(props.group.schedules.length - 1, 0),
+)
 </script>
 
 <style scoped>
@@ -45,5 +51,11 @@ const primarySchedule = computed(() => props.group.schedules[0])
   display: inline-flex;
   align-items: center;
   gap: 6px;
+}
+
+.ps-card__more {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  color: var(--color-asphalt-55);
 }
 </style>

--- a/components/group/GroupDetails.vue
+++ b/components/group/GroupDetails.vue
@@ -7,45 +7,37 @@
       <h1 class="ps-h1 group-title">{{ group.name }}</h1>
     </div>
 
-    <GroupMetaBadges v-if="primarySchedule" :schedule="primarySchedule" />
-
     <div class="group-grid">
       <div class="group-col">
         <section>
           <h2 class="section-title">
-            <PsIcon name="calendar" :size="16" /> Agenda
+            <PsIcon name="calendar" :size="16" /> {{ agendaTitle }}
           </h2>
-          <div v-if="primarySchedule" class="meta-grid">
-            <div class="meta-cell">
-              <div class="ps-label">Dia &amp; saída</div>
-              <div class="v">
-                {{ primarySchedule.day }} · {{ primarySchedule.startHour }}
-              </div>
-            </div>
-            <div class="meta-cell">
-              <div class="ps-label">Ponto de saída</div>
-              <div class="v v--addr">{{ departure }}</div>
-            </div>
-            <div v-if="primarySchedule.distanceKm > 0" class="meta-cell">
-              <div class="ps-label">Distância</div>
-              <div class="v">{{ primarySchedule.distanceKm }} km</div>
-            </div>
-            <div v-if="primarySchedule.rhythmKmH > 0" class="meta-cell">
-              <div class="ps-label">Ritmo médio</div>
-              <div class="v">{{ primarySchedule.rhythmKmH }} km/h</div>
-            </div>
-            <div class="meta-cell">
-              <div class="ps-label">Nível</div>
-              <div class="v">{{ primarySchedule.effort }}</div>
-            </div>
-            <div v-if="duration" class="meta-cell">
-              <div class="ps-label">Volta média</div>
-              <div class="v">{{ duration }}</div>
-            </div>
-          </div>
+
+          <ul v-if="group.schedules.length" class="agenda-list">
+            <li
+              v-for="schedule in group.schedules"
+              :key="schedule.id"
+              class="agenda-item"
+            >
+              <GroupMetaBadges :schedule="schedule" />
+              <p v-if="lapDuration(schedule)" class="agenda-dur">
+                <PsIcon name="compass" :size="14" /> Volta média:
+                <strong>{{ lapDuration(schedule) }}</strong>
+              </p>
+            </li>
+          </ul>
           <p v-else class="ps-body group-muted">
             Agenda ainda não cadastrada para este grupo.
           </p>
+
+          <ContributionLink
+            context="schedule"
+            :slug="group.slug"
+            icon="plus"
+            variant="ghost"
+            class="agenda-add"
+          />
         </section>
 
         <section>
@@ -105,7 +97,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { getEstimatedLapDuration } from '../../lib/time'
-import type { Group } from '../../types/group'
+import type { Group, GroupSchedule } from '../../types/group'
 import ContributionLink from '../contribution/ContributionLink.vue'
 import GroupLocationMap from './GroupLocationMap.client.vue'
 import GroupMetaBadges from './GroupMetaBadges.vue'
@@ -114,23 +106,52 @@ const props = defineProps<{
   group: Group
 }>()
 
-const primarySchedule = computed(() => props.group.schedules[0])
+const agendaTitle = computed(() =>
+  props.group.schedules.length > 1 ? 'Agendas' : 'Agenda',
+)
 const departure = computed(
   () => props.group.departureAddress || 'Ponto de saída no mapa',
 )
-const duration = computed(() =>
-  primarySchedule.value
-    ? getEstimatedLapDuration({
-        distanceKm: primarySchedule.value.distanceKm,
-        rhythmKmH: primarySchedule.value.rhythmKmH,
-      })
-    : null,
-)
+
+// volta média por agenda (distância 0 / ritmo 0 = não informado → sem volta)
+function lapDuration(schedule: GroupSchedule): string | null {
+  return getEstimatedLapDuration({
+    distanceKm: schedule.distanceKm,
+    rhythmKmH: schedule.rhythmKmH,
+  })
+}
 </script>
 
 <style scoped>
 .group-title {
   font-size: var(--text-2xl);
+}
+
+.agenda-list {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-4);
+  padding: 0;
+  list-style: none;
+}
+
+.agenda-item {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 2px solid var(--color-border);
+}
+
+.agenda-dur {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+.agenda-add {
+  margin-top: var(--space-1);
 }
 
 .group-actions {

--- a/lib/contribution.ts
+++ b/lib/contribution.ts
@@ -1,8 +1,25 @@
-export type ContributionContext = 'new-group' | 'correction' | 'removal'
+import type { Group } from '../types/group'
+
+export type ContributionContext =
+  | 'new-group'
+  | 'correction'
+  | 'removal'
+  | 'schedule'
+
+/**
+ * Escolha do grupo no fluxo "adicionar agenda": um grupo que já existe (anexa a
+ * agenda, sem duplicar) ou um grupo novo (cria grupo + agenda). `null` = nada
+ * escolhido ainda. O combobox emite isso; o form decide a request a partir do
+ * `kind`.
+ */
+export type GroupSelection =
+  | { kind: 'existing'; group: Group }
+  | { kind: 'new'; name: string }
 
 /**
  * Rotas internas dos fluxos de contribuição. Correção/remoção sem slug caem
- * na página de escolha de grupo (/contribute/correction).
+ * na página de escolha de grupo (/contribute/correction). Para "adicionar
+ * agenda", o slug pré-seleciona o grupo via query (`?group=`).
  */
 export function getContributionRoute(
   context: ContributionContext,
@@ -14,6 +31,9 @@ export function getContributionRoute(
   if (context === 'removal') {
     return slug ? `/contribute/removal/${slug}` : '/contribute/correction'
   }
+  if (context === 'schedule') {
+    return slug ? `/contribute/schedule?group=${slug}` : '/contribute/schedule'
+  }
   return '/contribute'
 }
 
@@ -23,6 +43,9 @@ export function getContributionLabel(context: ContributionContext): string {
   }
   if (context === 'removal') {
     return 'Solicitar remoção'
+  }
+  if (context === 'schedule') {
+    return 'Adicionar agenda'
   }
   return 'Sugerir grupo'
 }

--- a/lib/curation.ts
+++ b/lib/curation.ts
@@ -114,6 +114,23 @@ export function groupCreateInputFromPayload(
   return input
 }
 
+/**
+ * Monta o `GroupUpdateInput` que ANEXA uma agenda a um grupo já existente, a
+ * partir de uma sugestão CREATE com grupo alvo (fluxo "adicionar agenda"). Usa
+ * o create aninhado de `groupInfos`, que não toca nas agendas existentes.
+ * `null` se a agenda estiver incompleta — não deveria ocorrer, pois a validação
+ * exige os cinco campos de agenda nesse fluxo.
+ */
+export function addScheduleUpdateFromPayload(
+  payload: SuggestionGroupPayload,
+): GroupUpdateInput | null {
+  const schedule = groupInfoCreateInputFromPayload(payload)
+  if (!schedule) {
+    return null
+  }
+  return { groupInfos: { create: [schedule] } }
+}
+
 export type GroupUpdateParts = {
   group?: GroupUpdateInput
   groupInfo?: GroupInfoUpdateInput

--- a/lib/suggestion-form.ts
+++ b/lib/suggestion-form.ts
@@ -97,6 +97,22 @@ export function parseDurationToMinutes(value: string): number | null {
   return total > 0 ? total : null
 }
 
+/**
+ * A agenda traz os cinco campos exigidos (dia/horário/nível/distância/ritmo)?
+ * Espelha a regra do servidor (`SCHEDULE_FIELDS` em suggestion-schemas) para o
+ * fluxo "adicionar agenda" avisar cedo, antes do round-trip. O servidor continua
+ * sendo a fonte de verdade.
+ */
+export function hasCompleteSchedule(payload: SuggestionGroupPayload): boolean {
+  return (
+    payload.day !== undefined &&
+    payload.startHour !== undefined &&
+    payload.effort !== undefined &&
+    payload.distanceKm !== undefined &&
+    payload.rhythmKmH !== undefined
+  )
+}
+
 /** Converte os inputs em payload, descartando campos vazios. */
 export function payloadFromFields(
   fields: SuggestionFormFields,

--- a/lib/suggestion-form.ts
+++ b/lib/suggestion-form.ts
@@ -1,4 +1,8 @@
-import type { GroupRecord, SuggestionGroupPayload } from '../types/suggestion'
+import type {
+  GroupRecord,
+  GroupScheduleRecord,
+  SuggestionGroupPayload,
+} from '../types/suggestion'
 import { getRhythmFromDistanceAndDuration } from './time'
 
 /**
@@ -40,6 +44,27 @@ const TEXT_FIELDS: ReadonlyArray<TextField> = [
   'effort',
 ]
 
+// diffPayload compara os campos do grupo contra o `record` e os da agenda contra
+// a agenda escolhida — daí a separação (payloadFromFields usa as listas acima).
+const GROUP_TEXT_FIELDS: ReadonlyArray<'name' | 'linkUrl' | 'address'> = [
+  'name',
+  'linkUrl',
+  'address',
+]
+const GROUP_NUMERIC_FIELDS: ReadonlyArray<'latitude' | 'longitude'> = [
+  'latitude',
+  'longitude',
+]
+const SCHEDULE_TEXT_FIELDS: ReadonlyArray<'day' | 'startHour' | 'effort'> = [
+  'day',
+  'startHour',
+  'effort',
+]
+const SCHEDULE_NUMERIC_FIELDS: ReadonlyArray<'distanceKm' | 'rhythmKmH'> = [
+  'distanceKm',
+  'rhythmKmH',
+]
+
 export function emptyFields(): SuggestionFormFields {
   return {
     name: '',
@@ -56,17 +81,23 @@ export function emptyFields(): SuggestionFormFields {
   }
 }
 
-export function fieldsFromRecord(record: GroupRecord): SuggestionFormFields {
+/** Pré-preenche o form com os campos do grupo (`record`) e os da agenda escolhida
+ *  (`schedule`). Sem agenda (grupo sem GroupInfo), os campos de agenda ficam vazios. */
+export function fieldsFromRecord(
+  record: GroupRecord,
+  schedule?: GroupScheduleRecord,
+): SuggestionFormFields {
   return {
     name: record.name,
     linkUrl: record.linkUrl ?? '',
     address: record.address ?? '',
-    day: record.day ?? '',
-    startHour: record.startHour ?? '',
-    effort: record.effort ?? '',
+    day: schedule?.day ?? '',
+    startHour: schedule?.startHour ?? '',
+    effort: schedule?.effort ?? '',
     distanceKm:
-      record.distanceKm !== undefined ? String(record.distanceKm) : '',
-    rhythmKmH: record.rhythmKmH !== undefined ? String(record.rhythmKmH) : '',
+      schedule?.distanceKm !== undefined ? String(schedule.distanceKm) : '',
+    rhythmKmH:
+      schedule?.rhythmKmH !== undefined ? String(schedule.rhythmKmH) : '',
     // o grupo publicado não guarda duração; o ritmo já vem preenchido acima
     durationHhmm: '',
     latitude: String(record.latitude),
@@ -113,6 +144,17 @@ export function hasCompleteSchedule(payload: SuggestionGroupPayload): boolean {
   )
 }
 
+/** Rótulo curto de uma agenda para seletores (ex.: "Quinta · 19:00 · Avançado"). */
+export function scheduleLabel(
+  schedule: GroupScheduleRecord,
+  index: number,
+): string {
+  const parts = [schedule.day, schedule.startHour, schedule.effort].filter(
+    (value): value is string => Boolean(value),
+  )
+  return parts.length > 0 ? parts.join(' · ') : `Agenda ${index + 1}`
+}
+
 /** Converte os inputs em payload, descartando campos vazios. */
 export function payloadFromFields(
   fields: SuggestionFormFields,
@@ -153,26 +195,41 @@ export function payloadFromFields(
 }
 
 /**
- * Correction payload: only the fields whose value differs from the published record,
- * so curation sees exactly what changed. A field left empty counts as
- * "unchanged" (asking to clear a field goes in the justification).
+ * Correction payload: only the fields whose value differs from the published
+ * record, so curation sees exactly what changed. Group fields are compared
+ * against the `record`; schedule fields against the chosen `schedule` (so
+ * correcting agenda #2 diffs against #2, not the first). A field left empty
+ * counts as "unchanged" (asking to clear a field goes in the justification).
  */
 export function diffPayload(
   fields: SuggestionFormFields,
   record: GroupRecord,
+  schedule?: GroupScheduleRecord,
 ): SuggestionGroupPayload {
   const proposed = payloadFromFields(fields)
   const diff: SuggestionGroupPayload = {}
 
-  for (const field of TEXT_FIELDS) {
+  for (const field of GROUP_TEXT_FIELDS) {
     const value = proposed[field]
     if (value !== undefined && value !== (record[field] ?? '')) {
       diff[field] = value
     }
   }
-  for (const field of NUMERIC_FIELDS) {
+  for (const field of GROUP_NUMERIC_FIELDS) {
     const value = proposed[field]
     if (value !== undefined && value !== record[field]) {
+      diff[field] = value
+    }
+  }
+  for (const field of SCHEDULE_TEXT_FIELDS) {
+    const value = proposed[field]
+    if (value !== undefined && value !== (schedule?.[field] ?? '')) {
+      diff[field] = value
+    }
+  }
+  for (const field of SCHEDULE_NUMERIC_FIELDS) {
+    const value = proposed[field]
+    if (value !== undefined && value !== schedule?.[field]) {
       diff[field] = value
     }
   }

--- a/lib/suggestion-notification.ts
+++ b/lib/suggestion-notification.ts
@@ -38,7 +38,10 @@ function truncate(text: string, max: number): string {
 /** Campos preenchidos do payload — usado no resumo de um UPDATE. */
 function filledFields(payload: SuggestionGroupPayload): string[] {
   return Object.entries(payload)
-    .filter(([, value]) => value !== undefined && value !== null)
+    .filter(
+      ([key, value]) =>
+        key !== 'scheduleId' && value !== undefined && value !== null,
+    )
     .map(([key]) => key)
 }
 
@@ -55,6 +58,11 @@ export function buildDiscordMessage(
     lines.push(`**Grupo:** ${notice.payload.name}`)
   } else if (notice.targetId) {
     lines.push(`**Grupo alvo:** \`${notice.targetId}\``)
+  }
+
+  // correção/remoção de UMA agenda específica
+  if (notice.payload?.scheduleId) {
+    lines.push(`**Agenda alvo:** \`${notice.payload.scheduleId}\``)
   }
 
   if (isAddSchedule && notice.payload) {

--- a/lib/suggestion-notification.ts
+++ b/lib/suggestion-notification.ts
@@ -46,15 +46,32 @@ function filledFields(payload: SuggestionGroupPayload): string[] {
 export function buildDiscordMessage(
   notice: NewSuggestionNotice,
 ): DiscordWebhookPayload {
-  const lines = [`🚲 **Nova sugestão · ${TYPE_LABEL[notice.type]}**`]
+  // CREATE com grupo alvo = adicionar agenda a um grupo existente
+  const isAddSchedule = notice.type === 'CREATE' && Boolean(notice.targetId)
+  const label = isAddSchedule ? 'nova agenda' : TYPE_LABEL[notice.type]
+  const lines = [`🚲 **Nova sugestão · ${label}**`]
 
-  if (notice.type === 'CREATE' && notice.payload?.name) {
+  if (notice.type === 'CREATE' && !isAddSchedule && notice.payload?.name) {
     lines.push(`**Grupo:** ${notice.payload.name}`)
   } else if (notice.targetId) {
     lines.push(`**Grupo alvo:** \`${notice.targetId}\``)
   }
 
-  if (notice.type === 'UPDATE' && notice.payload) {
+  if (isAddSchedule && notice.payload) {
+    const p = notice.payload
+    const parts = [p.day, p.startHour, p.effort].filter(
+      (value): value is string => Boolean(value),
+    )
+    if (p.distanceKm !== undefined) {
+      parts.push(`${p.distanceKm} km`)
+    }
+    if (p.rhythmKmH !== undefined) {
+      parts.push(`${p.rhythmKmH} km/h`)
+    }
+    if (parts.length > 0) {
+      lines.push(`**Agenda:** ${parts.join(' · ')}`)
+    }
+  } else if (notice.type === 'UPDATE' && notice.payload) {
     const fields = filledFields(notice.payload)
     if (fields.length > 0) {
       lines.push(`**Campos:** ${fields.join(', ')}`)

--- a/lib/suggestion-notification.ts
+++ b/lib/suggestion-notification.ts
@@ -95,7 +95,9 @@ export function buildDiscordMessage(
   if (notice.contactEmail) {
     lines.push(`**Contato:** ${notice.contactEmail}`)
   }
-  lines.push(`\`id: ${notice.id}\``)
+  // id do registro Suggestion no Hygraph — o curador usa pra achar e avaliar
+  // esta sugestão no Studio/CLI de curadoria; code inline facilita copiar
+  lines.push(`**ID da sugestão:** \`${notice.id}\``)
 
   return {
     content: truncate(lines.join('\n'), DISCORD_CONTENT_LIMIT),

--- a/lib/suggestion-notification.ts
+++ b/lib/suggestion-notification.ts
@@ -9,6 +9,8 @@ export type NewSuggestionNotice = {
   type: SuggestionType
   justification: string
   targetId?: string
+  /** Nome do grupo alvo, para dar contexto além do id opaco. */
+  targetName?: string
   contactEmail?: string
   payload?: SuggestionGroupPayload
 }
@@ -57,7 +59,10 @@ export function buildDiscordMessage(
   if (notice.type === 'CREATE' && !isAddSchedule && notice.payload?.name) {
     lines.push(`**Grupo:** ${notice.payload.name}`)
   } else if (notice.targetId) {
-    lines.push(`**Grupo alvo:** \`${notice.targetId}\``)
+    const ref = notice.targetName
+      ? `${notice.targetName} \`${notice.targetId}\``
+      : `\`${notice.targetId}\``
+    lines.push(`**Grupo alvo:** ${ref}`)
   }
 
   // correção/remoção de UMA agenda específica

--- a/lib/suggestion-schemas.ts
+++ b/lib/suggestion-schemas.ts
@@ -53,6 +53,8 @@ export const payloadSchema = z
       .number('Longitude deve ser um número')
       .min(SP_BOUNDS.lngMin, 'Longitude fora da região de São Paulo')
       .max(SP_BOUNDS.lngMax, 'Longitude fora da região de São Paulo'),
+    // alvo de UMA agenda (id do GroupInfo) em UPDATE/DELETE — não é editável
+    scheduleId: z.string().trim().min(1).max(64),
   })
   .partial()
 
@@ -95,8 +97,10 @@ export const suggestionSchema = baseSchema.superRefine((data, ctx) => {
   // o modo "adicionar agenda" valida por campo abaixo, com mensagens próprias
   const needsGenericPayload =
     (data.type === 'CREATE' && !isAddSchedule) || data.type === 'UPDATE'
-  const filledFieldCount = Object.values(data.payload ?? {}).filter(
-    (value) => value !== undefined,
+  // scheduleId é alvo (qual agenda), não um campo editável — fora da contagem,
+  // então um DELETE pode levar só scheduleId e um UPDATE exige uma mudança real
+  const filledFieldCount = Object.entries(data.payload ?? {}).filter(
+    ([key, value]) => key !== 'scheduleId' && value !== undefined,
   ).length
 
   if (needsTarget && !data.targetId) {

--- a/lib/suggestion-schemas.ts
+++ b/lib/suggestion-schemas.ts
@@ -73,10 +73,28 @@ const baseSchema = z.object({
 const REQUIRED_CREATE_FIELDS: ReadonlyArray<'name' | 'latitude' | 'longitude'> =
   ['name', 'latitude', 'longitude']
 
-/** Conditional rules per type: target required for UPDATE/DELETE, payload for CREATE/UPDATE. */
+/** Campos que definem uma agenda (GroupInfo) — exigidos ao adicionar uma agenda. */
+const SCHEDULE_FIELDS: ReadonlyArray<
+  'day' | 'startHour' | 'effort' | 'distanceKm' | 'rhythmKmH'
+> = ['day', 'startHour', 'effort', 'distanceKm', 'rhythmKmH']
+
+/** Campos do grupo (não da agenda) — recusados ao adicionar agenda a um grupo existente. */
+const GROUP_ONLY_FIELDS: ReadonlyArray<
+  'name' | 'linkUrl' | 'address' | 'latitude' | 'longitude'
+> = ['name', 'linkUrl', 'address', 'latitude', 'longitude']
+
+/**
+ * Regras condicionais por tipo. CREATE tem dois modos: sem `targetId` cria um
+ * grupo novo (exige name+ponto); COM `targetId` adiciona uma agenda a um grupo
+ * existente (exige os campos da agenda e recusa os do grupo — eles já existem).
+ * UPDATE/DELETE exigem `targetId`.
+ */
 export const suggestionSchema = baseSchema.superRefine((data, ctx) => {
+  const isAddSchedule = data.type === 'CREATE' && data.targetId !== undefined
   const needsTarget = data.type === 'UPDATE' || data.type === 'DELETE'
-  const needsPayload = data.type === 'CREATE' || data.type === 'UPDATE'
+  // o modo "adicionar agenda" valida por campo abaixo, com mensagens próprias
+  const needsGenericPayload =
+    (data.type === 'CREATE' && !isAddSchedule) || data.type === 'UPDATE'
   const filledFieldCount = Object.values(data.payload ?? {}).filter(
     (value) => value !== undefined,
   ).length
@@ -89,7 +107,7 @@ export const suggestionSchema = baseSchema.superRefine((data, ctx) => {
     })
   }
 
-  if (needsPayload && filledFieldCount === 0) {
+  if (needsGenericPayload && filledFieldCount === 0) {
     ctx.addIssue({
       code: 'custom',
       path: ['payload'],
@@ -100,7 +118,26 @@ export const suggestionSchema = baseSchema.superRefine((data, ctx) => {
     })
   }
 
-  if (data.type === 'CREATE') {
+  if (isAddSchedule) {
+    for (const field of SCHEDULE_FIELDS) {
+      if (data.payload?.[field] === undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['payload', field],
+          message: 'Campo obrigatório para a agenda',
+        })
+      }
+    }
+    for (const field of GROUP_ONLY_FIELDS) {
+      if (data.payload?.[field] !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['payload', field],
+          message: 'Este dado é do grupo e não muda ao adicionar uma agenda',
+        })
+      }
+    }
+  } else if (data.type === 'CREATE') {
     for (const field of REQUIRED_CREATE_FIELDS) {
       if (data.payload?.[field] === undefined) {
         ctx.addIssue({

--- a/lib/suggestion-service.ts
+++ b/lib/suggestion-service.ts
@@ -26,6 +26,9 @@ const GROUP_EXISTS_QUERY = /* GraphQL */ `
     group(where: { id: $id }) {
       id
       name
+      groupInfos {
+        id
+      }
     }
   }
 `
@@ -105,6 +108,31 @@ function readGroupName(data: unknown): string | undefined {
   return undefined
 }
 
+/** Lê os ids das agendas (`data.group.groupInfos[].id`) do grupo alvo. */
+function readScheduleIds(data: unknown): string[] {
+  if (!data || typeof data !== 'object' || !('group' in data)) {
+    return []
+  }
+  const node = Reflect.get(data, 'group')
+  if (!node || typeof node !== 'object' || !('groupInfos' in node)) {
+    return []
+  }
+  const infos = Reflect.get(node, 'groupInfos')
+  if (!Array.isArray(infos)) {
+    return []
+  }
+  const ids: string[] = []
+  for (const info of infos) {
+    if (info && typeof info === 'object' && 'id' in info) {
+      const id = Reflect.get(info, 'id')
+      if (typeof id === 'string') {
+        ids.push(id)
+      }
+    }
+  }
+  return ids
+}
+
 /** Valida o corpo cru e lança `SuggestionError` 400 com issues por campo. */
 export function parseSuggestion(body: unknown): ValidatedSuggestion {
   const parsed = suggestionSchema.safeParse(body)
@@ -151,6 +179,13 @@ export async function createSuggestion(
     }
     // nome do alvo dá contexto no aviso do Discord (o id sozinho é opaco)
     targetName = readGroupName(target)
+
+    // corrigir/remover UMA agenda: confirma que ela é do grupo alvo (o id viaja
+    // no payload e não passa pelo schema relacional — validamos aqui)
+    const scheduleId = payload?.scheduleId
+    if (scheduleId && !readScheduleIds(target).includes(scheduleId)) {
+      throw new SuggestionError(404, 'Agenda alvo não encontrada no grupo')
+    }
   }
 
   const variables: Record<string, unknown> = {

--- a/lib/suggestion-service.ts
+++ b/lib/suggestion-service.ts
@@ -137,7 +137,9 @@ export async function createSuggestion(
 
   const variables: Record<string, unknown> = {
     type,
-    payload: type === 'DELETE' ? undefined : payload,
+    // DELETE normalmente não tem payload; quando tem, é só { scheduleId } (remover
+    // UMA agenda) — o schema garante isso, então persistimos o payload validado
+    payload,
     justification,
     contactEmail: contactEmail || undefined,
   }

--- a/lib/suggestion-service.ts
+++ b/lib/suggestion-service.ts
@@ -25,6 +25,7 @@ const GROUP_EXISTS_QUERY = /* GraphQL */ `
   query groupExists($id: ID!) {
     group(where: { id: $id }) {
       id
+      name
     }
   }
 `
@@ -90,6 +91,20 @@ function readIdFromResponse(
   return null
 }
 
+/** Lê `data.group.name` da checagem de existência (para dar contexto no aviso). */
+function readGroupName(data: unknown): string | undefined {
+  if (data && typeof data === 'object' && 'group' in data) {
+    const node = Reflect.get(data, 'group')
+    if (node && typeof node === 'object' && 'name' in node) {
+      const name = Reflect.get(node, 'name')
+      if (typeof name === 'string') {
+        return name
+      }
+    }
+  }
+  return undefined
+}
+
 /** Valida o corpo cru e lança `SuggestionError` 400 com issues por campo. */
 export function parseSuggestion(body: unknown): ValidatedSuggestion {
   const parsed = suggestionSchema.safeParse(body)
@@ -120,6 +135,7 @@ export async function createSuggestion(
   const { type, targetId, payload, justification, contactEmail } =
     parseSuggestion(body)
 
+  let targetName: string | undefined
   if (targetId) {
     let target: unknown
     try {
@@ -133,6 +149,8 @@ export async function createSuggestion(
     if (!readIdFromResponse(target, 'group')) {
       throw new SuggestionError(404, 'Grupo alvo não encontrado')
     }
+    // nome do alvo dá contexto no aviso do Discord (o id sozinho é opaco)
+    targetName = readGroupName(target)
   }
 
   const variables: Record<string, unknown> = {
@@ -170,5 +188,5 @@ export async function createSuggestion(
     )
   }
 
-  return { ok: true, id }
+  return { ok: true, id, targetName }
 }

--- a/pages/contribute/index.vue
+++ b/pages/contribute/index.vue
@@ -15,6 +15,10 @@
       <SuggestionCreateForm />
 
       <p class="ps-body contribute-alt">
+        O grupo já existe e você só quer adicionar um novo dia/horário?
+        <NuxtLink to="/contribute/schedule">Adicionar agenda</NuxtLink>
+      </p>
+      <p class="ps-body contribute-alt contribute-alt--tight">
         Quer corrigir um grupo que já existe?
         <NuxtLink to="/contribute/correction">Sugerir correção</NuxtLink>
       </p>
@@ -45,6 +49,10 @@ useSeoMeta({
 .contribute-alt {
   margin-top: var(--space-8);
   color: var(--color-asphalt-55);
+}
+
+.contribute-alt--tight {
+  margin-top: var(--space-2);
 }
 
 .contribute-alt a {

--- a/pages/contribute/schedule.vue
+++ b/pages/contribute/schedule.vue
@@ -1,0 +1,53 @@
+<template>
+  <main class="doc">
+    <div class="doc__inner">
+      <NuxtLink to="/" class="back-link">
+        <PsIcon name="chevronRight" :size="15" class="flip" /> Voltar ao mapa
+      </NuxtLink>
+
+      <p class="ps-eyebrow contribute-eyebrow">Mapa colaborativo</p>
+      <h1 class="ps-h1">Adicionar uma agenda</h1>
+      <p class="ps-lead contribute-lead">
+        Um grupo pode pedalar em mais de um dia e nível. Escolha o grupo na
+        lista (ou crie um novo) e descreva a agenda — passa por revisão antes de
+        ir ao ar.
+      </p>
+
+      <SuggestionScheduleForm
+        :groups="groups ?? []"
+        :pending="pending"
+        :preselect-slug="preselectSlug"
+      />
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import SuggestionScheduleForm from '../../components/contribution/SuggestionScheduleForm.vue'
+
+const route = useRoute()
+const { data: groups, pending } = useGroups()
+
+const preselectSlug = computed(() => {
+  const value = route.query.group
+  return typeof value === 'string' ? value : undefined
+})
+
+useSeoMeta({
+  title: 'Adicionar agenda - Pedala Sampa',
+  description:
+    'Adicione uma nova agenda (dia, horário e nível) a um grupo de pedal do mapa colaborativo do Pedala Sampa.',
+})
+</script>
+
+<style scoped>
+.contribute-eyebrow {
+  margin: var(--space-6) 0 var(--space-2);
+}
+
+.contribute-lead {
+  max-width: 680px;
+  margin: var(--space-4) 0 var(--space-8);
+}
+</style>

--- a/queries/curation.ts
+++ b/queries/curation.ts
@@ -75,7 +75,7 @@ export const GROUP_FOR_UPDATE_QUERY = /* GraphQL */ `
         latitude
         longitude
       }
-      groupInfos {
+      groupInfos(orderBy: createdAt_ASC) {
         id
       }
     }

--- a/queries/groups.ts
+++ b/queries/groups.ts
@@ -12,7 +12,7 @@ export const GET_GROUPS_QUERY = /* GraphQL */ `
         latitude
         longitude
       }
-      groupInfos {
+      groupInfos(orderBy: createdAt_ASC) {
         id
         startHour
         address
@@ -40,7 +40,7 @@ export const GET_GROUP_QUERY = /* GraphQL */ `
         latitude
         longitude
       }
-      groupInfos {
+      groupInfos(orderBy: createdAt_ASC) {
         id
         startHour
         address

--- a/scripts/curate-runner.ts
+++ b/scripts/curate-runner.ts
@@ -7,6 +7,7 @@ import { createInterface } from 'node:readline/promises'
 import { parseArgs } from 'node:util'
 import type { GraphQLClient } from 'graphql-request'
 import {
+  addScheduleUpdateFromPayload,
   groupCreateInputFromPayload,
   isScheduleComplete,
   slugify,
@@ -80,6 +81,10 @@ export function dryRunSummary(
   payload: SuggestionGroupPayload | null,
 ): string {
   if (s.type === 'CREATE' && payload) {
+    // CREATE com grupo alvo = adicionar agenda a um grupo existente
+    if (s.group) {
+      return `adicionaria 1 agenda ao grupo ${s.group.slug}`
+    }
     const schedule = isScheduleComplete(payload)
       ? ' + 1 agenda'
       : ' (sem agenda)'
@@ -152,6 +157,42 @@ export async function applyCreate(
     ? ''
     : ' (sem agenda — completar GroupInfo no Studio)'
   return `${createGroup.slug}${note}`
+}
+
+/**
+ * Adiciona uma agenda (GroupInfo) a um grupo já existente — fluxo "adicionar
+ * agenda" (CREATE com grupo alvo). Anexa via create aninhado, sem tocar nas
+ * agendas atuais. Mesmo cuidado de idempotência do applyCreate: se a marcação
+ * falhar depois de anexar, a sugestão segue PENDENTE e uma nova execução
+ * duplicaria a agenda — por isso o aviso explícito.
+ */
+export async function applyAddSchedule(
+  client: GraphQLClient,
+  s: PendingSuggestion,
+  payload: SuggestionGroupPayload,
+): Promise<string> {
+  if (!s.group) {
+    throw new Error('CREATE de agenda sem grupo alvo')
+  }
+  const data = addScheduleUpdateFromPayload(payload)
+  if (!data) {
+    throw new Error(
+      'agenda incompleta (faltam dia/horário/nível/distância/ritmo)',
+    )
+  }
+  await client.request(UPDATE_GROUP_MUTATION, { id: s.group.id, data })
+  try {
+    await mark(client, s.id, 'APPROVED')
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Agenda adicionada ao grupo "${s.group.slug}" (DRAFT), mas falhou ao ` +
+        `marcar a sugestão como APPROVED: ${reason}. A sugestão continua ` +
+        `PENDENTE — marque-a no Studio antes de rodar de novo para não ` +
+        `duplicar a agenda.`,
+    )
+  }
+  return s.group.name
 }
 
 export async function applyUpdate(
@@ -290,7 +331,13 @@ export async function main(client: GraphQLClient): Promise<void> {
       .trim()
       .toLowerCase()
     try {
-      if (answer === 'a' && s.type === 'CREATE' && payload) {
+      if (answer === 'a' && s.type === 'CREATE' && payload && s.group) {
+        toPublish.push(
+          `Agenda em ${await applyAddSchedule(client, s, payload)}`,
+        )
+        applied += 1
+        console.log('  ✓ agenda adicionada (DRAFT) + sugestão APPROVED\n')
+      } else if (answer === 'a' && s.type === 'CREATE' && payload) {
         toPublish.push(`Group ${await applyCreate(client, s, payload)}`)
         applied += 1
         console.log('  ✓ criado (DRAFT) + sugestão APPROVED\n')

--- a/scripts/curate-runner.ts
+++ b/scripts/curate-runner.ts
@@ -92,11 +92,17 @@ export function dryRunSummary(
   }
   if (s.type === 'UPDATE' && payload) {
     const fields = Object.entries(payload)
-      .filter(([, value]) => value !== undefined && value !== null)
+      .filter(
+        ([key, value]) =>
+          key !== 'scheduleId' && value !== undefined && value !== null,
+      )
       .map(([key]) => key)
-    return `atualizaria ${s.group?.slug ?? '?'}: ${fields.join(', ')}`
+    const agenda = payload.scheduleId ? ` (agenda ${payload.scheduleId})` : ''
+    return `atualizaria ${s.group?.slug ?? '?'}${agenda}: ${fields.join(', ')}`
   }
-  return `marcaria APPROVED e lembraria de despublicar ${s.group?.slug ?? '?'}`
+  const scheduleId = s.payload?.scheduleId
+  const agenda = scheduleId ? ` (agenda ${scheduleId})` : ''
+  return `marcaria APPROVED e lembraria de despublicar ${s.group?.slug ?? '?'}${agenda}`
 }
 
 async function mark(
@@ -222,15 +228,21 @@ export async function applyUpdate(
   }
   let note = ''
   if (parts.groupInfo) {
-    const info = group.groupInfos[0]
+    // mira a agenda escolhida (scheduleId); sem ela, cai na primeira (compat)
+    const scheduleId = diff.scheduleId
+    const info = scheduleId
+      ? group.groupInfos.find((gi) => gi.id === scheduleId)
+      : group.groupInfos[0]
     if (!info) {
-      note = ' (sem GroupInfo para a agenda — criar no Studio)'
+      note = scheduleId
+        ? ` (agenda ${scheduleId} não encontrada no grupo — confira no Studio)`
+        : ' (sem GroupInfo para a agenda — criar no Studio)'
     } else {
       await client.request(UPDATE_GROUP_INFO_MUTATION, {
         id: info.id,
         data: parts.groupInfo,
       })
-      if (group.groupInfos.length > 1) {
+      if (!scheduleId && group.groupInfos.length > 1) {
         note = ` (atenção: ${group.groupInfos.length} agendas; apliquei na primeira)`
       }
     }
@@ -347,7 +359,11 @@ export async function main(client: GraphQLClient): Promise<void> {
         console.log('  ✓ atualizado (DRAFT) + sugestão APPROVED\n')
       } else if (answer === 'a' && s.type === 'DELETE') {
         await mark(client, s.id, 'APPROVED')
-        toUnpublish.push(s.group ? `${s.group.name} (${s.group.slug})` : s.id)
+        const scheduleId = s.payload?.scheduleId
+        const agenda = scheduleId ? ` — agenda ${scheduleId}` : ''
+        toUnpublish.push(
+          s.group ? `${s.group.name} (${s.group.slug})${agenda}` : s.id,
+        )
         applied += 1
         console.log('  ✓ sugestão APPROVED (despublicar no Studio)\n')
       } else if (answer === 'r') {

--- a/server/api/groups/[slug].get.ts
+++ b/server/api/groups/[slug].get.ts
@@ -18,7 +18,7 @@ const GET_GROUP_RECORD_QUERY = /* GraphQL */ `
         latitude
         longitude
       }
-      groupInfos {
+      groupInfos(orderBy: createdAt_ASC) {
         id
         startHour
         address

--- a/server/api/groups/[slug].get.ts
+++ b/server/api/groups/[slug].get.ts
@@ -1,6 +1,9 @@
 import { extractLinkUrl, normalizeHour } from '../../../lib/group-normalizers'
 import type { HygraphGroup } from '../../../types/hygraph'
-import type { GroupRecord } from '../../../types/suggestion'
+import type {
+  GroupRecord,
+  GroupScheduleRecord,
+} from '../../../types/suggestion'
 
 const GET_GROUP_RECORD_QUERY = /* GraphQL */ `
   query getGroupRecord($slug: String!) {
@@ -59,7 +62,18 @@ export default defineEventHandler(async (event): Promise<GroupRecord> => {
     throw createError({ statusCode: 404, message: 'Grupo não encontrado' })
   }
 
-  const info = group.groupInfos?.[0]
+  const infos = group.groupInfos ?? []
+  // address/ponto são do grupo (compartilhados) — vêm da 1ª agenda, por convenção
+  const firstInfo = infos[0]
+
+  const schedules: GroupScheduleRecord[] = infos.map((info) => ({
+    id: info.id,
+    day: info.day || undefined,
+    startHour: normalizeHour(info.startHour),
+    effort: info.effort || undefined,
+    distanceKm: typeof info.distance === 'number' ? info.distance : undefined,
+    rhythmKmH: typeof info.rhythm === 'number' ? info.rhythm : undefined,
+  }))
 
   // cache curto no CDN: o form de correção não precisa de dado fresquíssimo
   // e cada miss custa uma chamada autenticada ao Hygraph
@@ -74,13 +88,9 @@ export default defineEventHandler(async (event): Promise<GroupRecord> => {
     slug: group.slug || group.id,
     name: group.name || 'Grupo sem nome',
     linkUrl: extractLinkUrl(group.link?.html),
-    address: info?.address || undefined,
-    day: info?.day || undefined,
-    startHour: normalizeHour(info?.startHour),
-    effort: info?.effort || undefined,
-    distanceKm: typeof info?.distance === 'number' ? info.distance : undefined,
-    rhythmKmH: typeof info?.rhythm === 'number' ? info.rhythm : undefined,
+    address: firstInfo?.address || undefined,
     latitude,
     longitude,
+    schedules,
   }
 })

--- a/server/api/suggestions.post.ts
+++ b/server/api/suggestions.post.ts
@@ -110,6 +110,7 @@ export default defineEventHandler(async (event) => {
       type: parsed.type,
       justification: parsed.justification,
       targetId: parsed.targetId,
+      targetName: result.targetName,
       contactEmail: parsed.contactEmail,
       payload: parsed.payload,
     })

--- a/tests/unit/contribution.test.ts
+++ b/tests/unit/contribution.test.ts
@@ -25,9 +25,20 @@ describe('contribution routes', () => {
     )
   })
 
+  it('aponta adicionar agenda sem slug para a página de agenda', () => {
+    expect(getContributionRoute('schedule')).toBe('/contribute/schedule')
+  })
+
+  it('pré-seleciona o grupo via query ao adicionar agenda com slug', () => {
+    expect(getContributionRoute('schedule', 'pedal-noturno')).toBe(
+      '/contribute/schedule?group=pedal-noturno',
+    )
+  })
+
   it('tem rótulo para cada contexto', () => {
     expect(getContributionLabel('new-group')).toBe('Sugerir grupo')
     expect(getContributionLabel('correction')).toBe('Sugerir correção')
     expect(getContributionLabel('removal')).toBe('Solicitar remoção')
+    expect(getContributionLabel('schedule')).toBe('Adicionar agenda')
   })
 })

--- a/tests/unit/curate-runner.test.ts
+++ b/tests/unit/curate-runner.test.ts
@@ -186,6 +186,26 @@ describe('applyUpdate', () => {
     })
     expect(result).toContain('criar no Studio')
   })
+
+  it('mira a agenda escolhida pelo scheduleId (não a primeira)', async () => {
+    const { client, request } = clientWith([
+      {
+        group: { ...currentGroup, groupInfos: [{ id: 'gi1' }, { id: 'gi2' }] },
+      },
+      { updateGroupInfo: { id: 'gi2' } },
+      { updateSuggestion: { id: 's2' } },
+    ])
+    const result = await applyUpdate(client, updateSuggestion, {
+      distanceKm: 50,
+      scheduleId: 'gi2',
+    })
+    expect(result).toBe('Pedal da Sé')
+    // updateGroupInfo aplicado em gi2 (a 2ª), não na primeira
+    expect(request).toHaveBeenNthCalledWith(2, expect.any(String), {
+      id: 'gi2',
+      data: { distance: 50 },
+    })
+  })
 })
 
 describe('applyAddSchedule', () => {
@@ -247,6 +267,18 @@ describe('dryRunSummary', () => {
       group: { id: 'g1', slug: 'pedal-da-se', name: 'Pedal da Sé' },
     }
     expect(dryRunSummary(del, null)).toContain('despublicar pedal-da-se')
+  })
+
+  it('descreve um DELETE de uma agenda específica', () => {
+    const del: PendingSuggestion = {
+      ...createSuggestion,
+      type: 'DELETE',
+      payload: { scheduleId: 'gi9' },
+      group: { id: 'g1', slug: 'pedal-da-se', name: 'Pedal da Sé' },
+    }
+    const summary = dryRunSummary(del, null)
+    expect(summary).toContain('despublicar pedal-da-se')
+    expect(summary).toContain('agenda gi9')
   })
 })
 

--- a/tests/unit/curate-runner.test.ts
+++ b/tests/unit/curate-runner.test.ts
@@ -1,6 +1,7 @@
 import { GraphQLClient } from 'graphql-request'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  applyAddSchedule,
   applyCreate,
   applyUpdate,
   dryRunSummary,
@@ -60,6 +61,24 @@ const currentGroup = {
   id: 'g1',
   name: 'Pedal da Sé',
   departureLocation: { latitude: -23.55, longitude: -46.63 },
+}
+
+const fullSchedulePayload = {
+  day: 'Quinta',
+  startHour: '19:00',
+  effort: 'Avançado',
+  distanceKm: 45,
+  rhythmKmH: 25,
+}
+
+const addScheduleSuggestion: PendingSuggestion = {
+  id: 's3',
+  type: 'CREATE',
+  payload: null,
+  justification: 'esse grupo também pedala na quinta',
+  contactEmail: null,
+  createdAt: '2026-06-03T12:00:00.000Z',
+  group: { id: 'g1', slug: 'pedal-da-se', name: 'Pedal da Sé' },
 }
 
 describe('resolveUniqueSlug', () => {
@@ -169,7 +188,52 @@ describe('applyUpdate', () => {
   })
 })
 
+describe('applyAddSchedule', () => {
+  it('anexa a agenda ao grupo existente e marca APPROVED', async () => {
+    const { client, request } = clientWith([
+      { updateGroup: { id: 'g1' } },
+      { updateSuggestion: { id: 's3' } },
+    ])
+    const result = await applyAddSchedule(
+      client,
+      addScheduleSuggestion,
+      fullSchedulePayload,
+    )
+    expect(result).toBe('Pedal da Sé')
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(request).toHaveBeenNthCalledWith(1, expect.any(String), {
+      id: 'g1',
+      data: {
+        groupInfos: { create: [expect.objectContaining({ rhythm: 25 })] },
+      },
+    })
+    expect(request).toHaveBeenLastCalledWith(expect.any(String), {
+      id: 's3',
+      status: 'APPROVED',
+    })
+  })
+
+  it('se a marcação falha após anexar, avisa para não duplicar', async () => {
+    const { client, request } = clientWith([{ updateGroup: { id: 'g1' } }])
+    request.mockRejectedValueOnce(new Error('rede caiu'))
+    let message = ''
+    try {
+      await applyAddSchedule(client, addScheduleSuggestion, fullSchedulePayload)
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    expect(message).toContain('pedal-da-se')
+    expect(message).toContain('duplicar')
+  })
+})
+
 describe('dryRunSummary', () => {
+  it('descreve um CREATE com grupo como adicionar agenda', () => {
+    const summary = dryRunSummary(addScheduleSuggestion, fullSchedulePayload)
+    expect(summary).toContain('adicionaria 1 agenda')
+    expect(summary).toContain('pedal-da-se')
+  })
+
   it('descreve um CREATE com agenda', () => {
     const summary = dryRunSummary(createSuggestion, fullCreatePayload)
     expect(summary).toContain('criaria Group "Pedal da Sé"')

--- a/tests/unit/curation.test.ts
+++ b/tests/unit/curation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  addScheduleUpdateFromPayload,
   buildLinkAst,
   groupCreateInputFromPayload,
   groupInfoCreateInputFromPayload,
@@ -164,5 +165,22 @@ describe('splitUpdatePayload', () => {
 
   it('retorna vazio quando não há nada a aplicar', () => {
     expect(splitUpdatePayload({}, current)).toEqual({})
+  })
+})
+
+describe('addScheduleUpdateFromPayload', () => {
+  it('anexa a agenda via create aninhado de groupInfos', () => {
+    const update = addScheduleUpdateFromPayload(fullSchedule)
+    expect(update).not.toBeNull()
+    expect(update?.groupInfos?.create).toHaveLength(1)
+    expect(update?.groupInfos?.create[0].rhythm).toBe(25)
+    expect(update?.groupInfos?.create[0].startHour).toBe('07:00h')
+    // não toca em campos do grupo (nome/local/link)
+    expect(update?.name).toBeUndefined()
+    expect(update?.departureLocation).toBeUndefined()
+  })
+
+  it('retorna null quando a agenda está incompleta', () => {
+    expect(addScheduleUpdateFromPayload({ day: 'Sábado' })).toBeNull()
   })
 })

--- a/tests/unit/curation.test.ts
+++ b/tests/unit/curation.test.ts
@@ -166,6 +166,13 @@ describe('splitUpdatePayload', () => {
   it('retorna vazio quando não há nada a aplicar', () => {
     expect(splitUpdatePayload({}, current)).toEqual({})
   })
+
+  it('ignora scheduleId (é alvo, não campo de Group/GroupInfo)', () => {
+    expect(splitUpdatePayload({ scheduleId: 'gi-2' }, current)).toEqual({})
+    expect(
+      splitUpdatePayload({ distanceKm: 50, scheduleId: 'gi-2' }, current),
+    ).toEqual({ groupInfo: { distance: 50 } })
+  })
 })
 
 describe('addScheduleUpdateFromPayload', () => {

--- a/tests/unit/suggestion-form.test.ts
+++ b/tests/unit/suggestion-form.test.ts
@@ -3,6 +3,7 @@ import {
   diffPayload,
   emptyFields,
   fieldsFromRecord,
+  hasCompleteSchedule,
   parseDurationToMinutes,
   payloadFromFields,
 } from '../../lib/suggestion-form'
@@ -176,5 +177,38 @@ describe('diffPayload', () => {
     }
     // o ritmo que faltava entra no diff por não existir no publicado
     expect(diffPayload(fields, recordNoRhythm)).toEqual({ rhythmKmH: 25 })
+  })
+})
+
+describe('hasCompleteSchedule', () => {
+  const schedule = {
+    ...emptyFields(),
+    day: 'Quinta',
+    startHour: '19:00',
+    effort: 'Avançado',
+    distanceKm: 45,
+    rhythmKmH: 28,
+  }
+
+  it('true quando os cinco campos da agenda vêm no payload', () => {
+    expect(hasCompleteSchedule(payloadFromFields(schedule))).toBe(true)
+  })
+
+  it('aceita ritmo derivado da duração (sem ritmo digitado)', () => {
+    const viaDuration = {
+      ...emptyFields(),
+      day: 'Quinta',
+      startHour: '19:00',
+      effort: 'Avançado',
+      distanceKm: 45,
+      durationHhmm: '01:30',
+    }
+    expect(hasCompleteSchedule(payloadFromFields(viaDuration))).toBe(true)
+  })
+
+  it('false quando falta um campo da agenda', () => {
+    expect(
+      hasCompleteSchedule(payloadFromFields({ ...schedule, effort: '' })),
+    ).toBe(false)
   })
 })

--- a/tests/unit/suggestion-form.test.ts
+++ b/tests/unit/suggestion-form.test.ts
@@ -6,8 +6,18 @@ import {
   hasCompleteSchedule,
   parseDurationToMinutes,
   payloadFromFields,
+  scheduleLabel,
 } from '../../lib/suggestion-form'
-import type { GroupRecord } from '../../types/suggestion'
+import type { GroupRecord, GroupScheduleRecord } from '../../types/suggestion'
+
+const schedule: GroupScheduleRecord = {
+  id: 'gi-1',
+  day: 'Sábado',
+  startHour: '07:00',
+  effort: 'Iniciante',
+  distanceKm: 25,
+  rhythmKmH: 18,
+}
 
 const record: GroupRecord = {
   id: 'grp-1',
@@ -15,13 +25,9 @@ const record: GroupRecord = {
   name: 'Pedal da Sé',
   linkUrl: 'https://instagram.com/pedaldase',
   address: 'Praça da Sé, 1',
-  day: 'Sábado',
-  startHour: '07:00',
-  effort: 'Iniciante',
-  distanceKm: 25,
-  rhythmKmH: 18,
   latitude: -23.55,
   longitude: -46.63,
+  schedules: [schedule],
 }
 
 describe('payloadFromFields', () => {
@@ -56,8 +62,8 @@ describe('payloadFromFields', () => {
   })
 
   it('diff não acusa mudança quando o number do input é igual ao publicado', () => {
-    const fields = { ...fieldsFromRecord(record), distanceKm: 25 }
-    expect(diffPayload(fields, record)).toEqual({})
+    const fields = { ...fieldsFromRecord(record, schedule), distanceKm: 25 }
+    expect(diffPayload(fields, record, schedule)).toEqual({})
   })
 
   it('deriva o ritmo da duração quando o ritmo não é informado', () => {
@@ -140,48 +146,72 @@ describe('parseDurationToMinutes', () => {
 
 describe('diffPayload', () => {
   it('retorna vazio quando nada mudou', () => {
-    expect(diffPayload(fieldsFromRecord(record), record)).toEqual({})
+    expect(
+      diffPayload(fieldsFromRecord(record, schedule), record, schedule),
+    ).toEqual({})
   })
 
-  it('contém apenas os campos alterados', () => {
-    const fields = fieldsFromRecord(record)
-    fields.address = 'Praça da Sé, 100'
-    fields.startHour = '06:30'
+  it('separa campos do grupo (vs record) e da agenda (vs schedule)', () => {
+    const fields = fieldsFromRecord(record, schedule)
+    fields.address = 'Praça da Sé, 100' // campo do grupo
+    fields.startHour = '06:30' // campo da agenda
 
-    expect(diffPayload(fields, record)).toEqual({
+    expect(diffPayload(fields, record, schedule)).toEqual({
       address: 'Praça da Sé, 100',
       startHour: '06:30',
     })
   })
 
   it('trata campo esvaziado como "sem alteração"', () => {
-    const fields = fieldsFromRecord(record)
+    const fields = fieldsFromRecord(record, schedule)
     fields.linkUrl = ''
 
-    expect(diffPayload(fields, record)).toEqual({})
+    expect(diffPayload(fields, record, schedule)).toEqual({})
   })
 
   it('detecta mudança numérica sem falso positivo de formatação', () => {
-    const fields = fieldsFromRecord(record)
+    const fields = fieldsFromRecord(record, schedule)
     fields.distanceKm = '25,0'
     fields.rhythmKmH = '20'
 
-    expect(diffPayload(fields, record)).toEqual({ rhythmKmH: 20 })
+    expect(diffPayload(fields, record, schedule)).toEqual({ rhythmKmH: 20 })
   })
 
-  it('deriva o ritmo da duração no diff quando o grupo não tinha ritmo', () => {
-    const recordNoRhythm: GroupRecord = { ...record, rhythmKmH: undefined }
+  it('diff da agenda compara com a agenda escolhida (não a 1ª)', () => {
+    const other: GroupScheduleRecord = {
+      id: 'gi-2',
+      day: 'Quinta',
+      startHour: '19:00',
+      effort: 'Avançado',
+      distanceKm: 45,
+      rhythmKmH: 28,
+    }
+    // pré-preenchido com a 2ª agenda; mudo só o nível
+    const fields = fieldsFromRecord(record, other)
+    fields.effort = 'Intermediário'
+    expect(diffPayload(fields, record, other)).toEqual({
+      effort: 'Intermediário',
+    })
+  })
+
+  it('deriva o ritmo da duração no diff quando a agenda não tinha ritmo', () => {
+    const scheduleNoRhythm: GroupScheduleRecord = {
+      ...schedule,
+      rhythmKmH: undefined,
+    }
     const fields = {
-      ...fieldsFromRecord(recordNoRhythm),
+      ...fieldsFromRecord(record, scheduleNoRhythm),
       durationHhmm: '01:00', // distância publicada (25 km) ÷ 1h = 25 km/h
     }
-    // o ritmo que faltava entra no diff por não existir no publicado
-    expect(diffPayload(fields, recordNoRhythm)).toEqual({ rhythmKmH: 25 })
+    // o ritmo que faltava entra no diff por não existir na agenda publicada
+    expect(diffPayload(fields, record, scheduleNoRhythm)).toEqual({
+      rhythmKmH: 25,
+    })
   })
 })
 
 describe('hasCompleteSchedule', () => {
-  const schedule = {
+  const fullSchedule = {
     ...emptyFields(),
     day: 'Quinta',
     startHour: '19:00',
@@ -191,7 +221,7 @@ describe('hasCompleteSchedule', () => {
   }
 
   it('true quando os cinco campos da agenda vêm no payload', () => {
-    expect(hasCompleteSchedule(payloadFromFields(schedule))).toBe(true)
+    expect(hasCompleteSchedule(payloadFromFields(fullSchedule))).toBe(true)
   })
 
   it('aceita ritmo derivado da duração (sem ritmo digitado)', () => {
@@ -208,7 +238,22 @@ describe('hasCompleteSchedule', () => {
 
   it('false quando falta um campo da agenda', () => {
     expect(
-      hasCompleteSchedule(payloadFromFields({ ...schedule, effort: '' })),
+      hasCompleteSchedule(payloadFromFields({ ...fullSchedule, effort: '' })),
     ).toBe(false)
+  })
+})
+
+describe('scheduleLabel', () => {
+  it('junta dia · horário · nível', () => {
+    expect(
+      scheduleLabel(
+        { id: 'x', day: 'Quinta', startHour: '19:00', effort: 'Avançado' },
+        0,
+      ),
+    ).toBe('Quinta · 19:00 · Avançado')
+  })
+
+  it('cai para "Agenda N" quando a agenda está vazia', () => {
+    expect(scheduleLabel({ id: 'x' }, 2)).toBe('Agenda 3')
   })
 })

--- a/tests/unit/suggestion-notification.test.ts
+++ b/tests/unit/suggestion-notification.test.ts
@@ -37,6 +37,26 @@ describe('buildDiscordMessage', () => {
     expect(msg.content).toContain('**Campos:** distanceKm, startHour')
   })
 
+  it('CREATE com targetId: rotula "nova agenda" e resume a agenda', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      targetId: 'grp1',
+      payload: {
+        day: 'Quinta',
+        startHour: '19:00',
+        effort: 'Avançado',
+        distanceKm: 45,
+        rhythmKmH: 28,
+      },
+    })
+    expect(msg.content).toContain('nova agenda')
+    expect(msg.content).not.toContain('novo grupo')
+    expect(msg.content).toContain('`grp1`')
+    expect(msg.content).toContain('**Agenda:**')
+    expect(msg.content).toContain('Quinta')
+    expect(msg.content).toContain('45 km')
+  })
+
   it('DELETE: mostra o alvo, sem listar campos', () => {
     const msg = buildDiscordMessage({
       ...base,

--- a/tests/unit/suggestion-notification.test.ts
+++ b/tests/unit/suggestion-notification.test.ts
@@ -91,6 +91,27 @@ describe('buildDiscordMessage', () => {
     expect(msg.content).toContain('**Agenda alvo:** `gi-2`')
   })
 
+  it('Grupo alvo inclui o nome além do id quando disponível', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      type: 'UPDATE',
+      targetId: 'grp1',
+      targetName: 'Fúria Norte Bikers',
+      payload: { startHour: '20:00' },
+    })
+    expect(msg.content).toContain('**Grupo alvo:** Fúria Norte Bikers `grp1`')
+  })
+
+  it('Grupo alvo cai só no id quando o nome não veio', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      type: 'UPDATE',
+      targetId: 'grp1',
+      payload: { startHour: '20:00' },
+    })
+    expect(msg.content).toContain('**Grupo alvo:** `grp1`')
+  })
+
   it('omite o contato quando ausente', () => {
     const msg = buildDiscordMessage({ ...base, payload: { name: 'X' } })
     expect(msg.content).not.toContain('Contato:')

--- a/tests/unit/suggestion-notification.test.ts
+++ b/tests/unit/suggestion-notification.test.ts
@@ -68,6 +68,29 @@ describe('buildDiscordMessage', () => {
     expect(msg.content).not.toContain('Campos:')
   })
 
+  it('UPDATE de uma agenda: mostra "Agenda alvo" e não lista scheduleId em Campos', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      type: 'UPDATE',
+      targetId: 'grp1',
+      payload: { startHour: '20:00', scheduleId: 'gi-2' },
+    })
+    expect(msg.content).toContain('**Agenda alvo:** `gi-2`')
+    expect(msg.content).toContain('**Campos:** startHour')
+    expect(msg.content).not.toContain('scheduleId')
+  })
+
+  it('DELETE de uma agenda: mostra "Agenda alvo"', () => {
+    const msg = buildDiscordMessage({
+      ...base,
+      type: 'DELETE',
+      targetId: 'grp1',
+      payload: { scheduleId: 'gi-2' },
+    })
+    expect(msg.content).toContain('remoção')
+    expect(msg.content).toContain('**Agenda alvo:** `gi-2`')
+  })
+
   it('omite o contato quando ausente', () => {
     const msg = buildDiscordMessage({ ...base, payload: { name: 'X' } })
     expect(msg.content).not.toContain('Contato:')

--- a/tests/unit/suggestion-notification.test.ts
+++ b/tests/unit/suggestion-notification.test.ts
@@ -22,7 +22,7 @@ describe('buildDiscordMessage', () => {
     expect(msg.content).toContain('**Grupo:** Pedal da Sé')
     expect(msg.content).toContain('grupo novo do meu bairro')
     expect(msg.content).toContain('**Contato:** foo@bar.com')
-    expect(msg.content).toContain('id: abc123')
+    expect(msg.content).toContain('**ID da sugestão:** `abc123`')
   })
 
   it('UPDATE: mostra o alvo e os campos alterados', () => {

--- a/tests/unit/suggestion-schemas.test.ts
+++ b/tests/unit/suggestion-schemas.test.ts
@@ -208,3 +208,45 @@ describe('suggestionSchema — adicionar agenda (CREATE + targetId)', () => {
     }
   })
 })
+
+describe('suggestionSchema — agenda específica (scheduleId)', () => {
+  it('UPDATE com scheduleId + um campo alterado é válido', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'UPDATE',
+      targetId: 'grp-1',
+      payload: { startHour: '20:00', scheduleId: 'gi-2' },
+      justification,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('UPDATE só com scheduleId (sem mudança real) é rejeitado', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'UPDATE',
+      targetId: 'grp-1',
+      payload: { scheduleId: 'gi-2' },
+      justification,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('DELETE com só scheduleId é válido (remover uma agenda)', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'DELETE',
+      targetId: 'grp-1',
+      payload: { scheduleId: 'gi-2' },
+      justification,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('DELETE com scheduleId + outro campo é rejeitado', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'DELETE',
+      targetId: 'grp-1',
+      payload: { scheduleId: 'gi-2', name: 'Outro' },
+      justification,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/tests/unit/suggestion-schemas.test.ts
+++ b/tests/unit/suggestion-schemas.test.ts
@@ -159,3 +159,52 @@ describe('suggestionSchema', () => {
     ).toBe(false)
   })
 })
+
+describe('suggestionSchema — adicionar agenda (CREATE + targetId)', () => {
+  const schedule = {
+    day: 'Quinta',
+    startHour: '19:00',
+    effort: 'Avançado',
+    distanceKm: 45,
+    rhythmKmH: 28,
+  }
+
+  it('aceita CREATE com targetId e agenda completa', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'CREATE',
+      targetId: 'grp-1',
+      payload: schedule,
+      justification,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejeita quando falta um campo da agenda', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'CREATE',
+      targetId: 'grp-1',
+      payload: { ...schedule, startHour: undefined },
+      justification,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((issue) => issue.path.join('.'))
+      expect(paths).toContain('payload.startHour')
+    }
+  })
+
+  it('recusa campos do grupo ao adicionar agenda (sem exigir name/lat/lng)', () => {
+    const result = suggestionSchema.safeParse({
+      type: 'CREATE',
+      targetId: 'grp-1',
+      payload: { ...schedule, name: 'Outro nome', latitude: -23.55 },
+      justification,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((issue) => issue.path.join('.'))
+      expect(paths).toContain('payload.name')
+      expect(paths).toContain('payload.latitude')
+    }
+  })
+})

--- a/tests/unit/suggestion-service.test.ts
+++ b/tests/unit/suggestion-service.test.ts
@@ -5,7 +5,7 @@ import type { HygraphRequest } from '../../lib/suggestion-service'
 const justification = 'O grupo mudou o ponto de saída no mês passado.'
 
 function hygraphMock(responses: {
-  group?: { id: string; name?: string } | null
+  group?: { id: string; name?: string; groupInfos?: { id: string }[] } | null
   createSuggestion?: { id: string } | null
 }) {
   return vi.fn<HygraphRequest>(async (query) =>
@@ -85,6 +85,41 @@ describe('createSuggestion', () => {
       id: 'sug-1',
       targetName: 'Pedal da Sé',
     })
+  })
+
+  it('retorna 404 quando a agenda alvo (scheduleId) não é do grupo', async () => {
+    const hygraph = hygraphMock({
+      group: { id: 'grp-1', groupInfos: [{ id: 'gi-1' }] },
+    })
+    const promise = createSuggestion(
+      {
+        type: 'DELETE',
+        targetId: 'grp-1',
+        payload: { scheduleId: 'gi-999' },
+        justification,
+      },
+      hygraph,
+    )
+
+    await expect(promise).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('aceita quando a agenda alvo (scheduleId) pertence ao grupo', async () => {
+    const hygraph = hygraphMock({
+      group: { id: 'grp-1', groupInfos: [{ id: 'gi-1' }, { id: 'gi-2' }] },
+    })
+    const result = await createSuggestion(
+      {
+        type: 'UPDATE',
+        targetId: 'grp-1',
+        payload: { startHour: '20:00', scheduleId: 'gi-2' },
+        justification,
+      },
+      hygraph,
+    )
+
+    expect(result).toEqual({ ok: true, id: 'sug-1' })
+    expect(hygraph).toHaveBeenCalledTimes(2)
   })
 
   it('retorna 502 quando o Hygraph falha', async () => {

--- a/tests/unit/suggestion-service.test.ts
+++ b/tests/unit/suggestion-service.test.ts
@@ -5,7 +5,7 @@ import type { HygraphRequest } from '../../lib/suggestion-service'
 const justification = 'O grupo mudou o ponto de saída no mês passado.'
 
 function hygraphMock(responses: {
-  group?: { id: string } | null
+  group?: { id: string; name?: string } | null
   createSuggestion?: { id: string } | null
 }) {
   return vi.fn<HygraphRequest>(async (query) =>
@@ -71,6 +71,20 @@ describe('createSuggestion', () => {
 
     expect(result).toEqual({ ok: true, id: 'sug-1' })
     expect(hygraph).toHaveBeenCalledTimes(2)
+  })
+
+  it('retorna o nome do grupo alvo (para dar contexto no aviso)', async () => {
+    const hygraph = hygraphMock({ group: { id: 'grp-1', name: 'Pedal da Sé' } })
+    const result = await createSuggestion(
+      { type: 'DELETE', targetId: 'grp-1', justification },
+      hygraph,
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      id: 'sug-1',
+      targetName: 'Pedal da Sé',
+    })
   })
 
   it('retorna 502 quando o Hygraph falha', async () => {

--- a/types/hygraph.ts
+++ b/types/hygraph.ts
@@ -76,6 +76,8 @@ export type GroupUpdateInput = {
   slug?: string
   departureLocation?: LocationInput
   link?: RichTextAst
+  /** Anexa agendas novas ao grupo (create aninhado), sem tocar nas existentes. */
+  groupInfos?: { create: GroupInfoCreateInput[] }
 }
 
 export type GroupInfoUpdateInput = {

--- a/types/suggestion.ts
+++ b/types/suggestion.ts
@@ -34,6 +34,8 @@ export type SuggestionRequest = {
 export type SuggestionResponse = {
   ok: true
   id: string
+  /** Nome do grupo alvo (UPDATE/DELETE/agenda) — usado no aviso do Discord. */
+  targetName?: string
 }
 
 /** Uma agenda publicada (GroupInfo) no snapshot de correção — campos opcionais

--- a/types/suggestion.ts
+++ b/types/suggestion.ts
@@ -14,6 +14,9 @@ export type SuggestionGroupPayload = {
   rhythmKmH?: number
   latitude?: number
   longitude?: number
+  /** Alvo (id do GroupInfo) ao corrigir/remover UMA agenda específica — não é um
+   *  campo editável; viaja no Json do payload. Ausente = grupo / 1ª agenda. */
+  scheduleId?: string
 }
 
 export type SuggestionRequest = {
@@ -33,18 +36,26 @@ export type SuggestionResponse = {
   id: string
 }
 
-/** Snapshot dos dados publicados de um grupo, para pré-preencher o form de correção. */
+/** Uma agenda publicada (GroupInfo) no snapshot de correção — campos opcionais
+ *  porque uma agenda pode estar incompleta no CMS. */
+export type GroupScheduleRecord = {
+  id: string
+  day?: string
+  startHour?: string
+  effort?: string
+  distanceKm?: number
+  rhythmKmH?: number
+}
+
+/** Snapshot dos dados publicados de um grupo, para pré-preencher o form de
+ *  correção. Campos de grupo no topo; cada agenda em `schedules`. */
 export type GroupRecord = {
   id: string
   slug: string
   name: string
   linkUrl?: string
   address?: string
-  day?: string
-  startHour?: string
-  effort?: string
-  distanceKm?: number
-  rhythmKmH?: number
   latitude: number
   longitude: number
+  schedules: GroupScheduleRecord[]
 }


### PR DESCRIPTION
## O que muda

Implementa o backlog **várias agendas por grupo**.

### Exibição
- `GroupDetails` lista **todas** as agendas (cada uma com badges + volta média), não só a primeira.
- `GroupCard` e `GroupQuickView` mostram **"+N agendas"** quando há mais de uma.
- Filtros já cobriam múltiplas agendas (`schedules.some`) — sem mudança.

### Contribuir — adicionar agenda (sem duplicar grupo)
- Nova página **`/contribute/schedule`** com um **combobox acessível** (`GroupCombobox.vue`, padrão ARIA: `role=combobox`, `aria-activedescendant`, teclado ↑↓/Enter/Esc) sobre os grupos existentes.
- O usuário escolhe **o grupo exato** da lista (anexa a agenda) ou clica **"➕ Criar novo"** (revela os campos de grupo inline). Aceita `?group=<slug>` para deep-link a partir da página do grupo.

### Modelo & backend (sem mudança de schema no Hygraph)
- "Agenda nova em grupo existente" = **`CREATE` + `targetId`**; `CREATE` sem target = grupo novo (como antes).
- Validação (`suggestion-schemas`) exige os 5 campos de agenda e **recusa** os campos de grupo nesse modo.
- O aviso no Discord rotula **"nova agenda"**.

### Curadoria
- `applyAddSchedule` anexa um `GroupInfo` ao grupo via `groupInfos: { create }`, com o mesmo cuidado de idempotência do `applyCreate`.

### Refactor
- `ScheduleFields.vue` extraído de `SuggestionGroupFields.vue`, reusado nos dois fluxos.

## Testes & verificação
- `yarn test` (131), `yarn typecheck`, `yarn lint`, `format:check`, `yarn build` — todos verdes.
- Smoke test no navegador com dados reais: combobox filtra/seleciona por teclado, campos condicionais, página do grupo com 2 agendas, "+N agendas" nos cards.

## Nota para a curadoria
A CLI `yarn curate` já trata o novo caso: a sugestão "adicionar agenda" aparece com o grupo alvo e, ao aplicar, anexa o `GroupInfo` ao grupo existente (sem criar grupo novo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
