### PR TITLE
chore(deps): sobe brace-expansion 2.x e 5.x (CVE-2026-13149, CVE-2026-14257)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3173,9 +3173,9 @@ brace-expansion@^2.0.1, brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,9 +3166,9 @@ boolbase@^1.0.0:
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 brace-expansion@^2.0.1, brace-expansion@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.3.tgz#1bf69aacdf6a4380ca17c284d9f928d4aa6401bc"
+  integrity sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
## Contexto

Fecha os **3 alertas de `brace-expansion`** do Dependabot — nenhum deles gerou PR automático. Os demais alertas foram cobertos pelos PRs #106–#110 (já mergeados na `develop`) e #111 (postcss, aberto).

| Alerta | CVE | Faixa vulnerável | Corrigido em | Estava em | Vai para |
|---|---|---|---|---|---|
| 253 | CVE-2026-13149 | `>= 3.0.0, < 5.0.7` | 5.0.7 | 5.0.6 | **5.0.8** |
| 266 | CVE-2026-14257 | `<= 5.0.7` | 5.0.8 | 5.0.6 | **5.0.8** |
| 263 | CVE-2026-13149 | `>= 2.0.0, < 2.1.2` | 2.1.2 | 2.1.1 | **2.1.3** |

- **CVE-2026-13149** (alta) — DoS por expansão em tempo exponencial de grupos `{}` consecutivos não-expansíveis. Emitido primeiro para a linha 5.x (alerta 253) e depois estendido para a 2.x (alerta 263).
- **CVE-2026-14257** (alta) — DoS por comprimento de expansão sem limite, causando crash do processo por falta de memória.

## O que foi feito

`brace-expansion` é dependência **transitiva** e aparece em duas entradas independentes do lockfile:

- `brace-expansion@^5.0.5` — puxada por `minimatch@10.2.5`
- `brace-expansion@^2.0.1, ^2.0.2` — puxada por vários consumidores do toolchain

Como o Yarn 1 não faz `upgrade` de transitivas, as duas entradas foram reresolvidas. Os ranges já permitiam as versões corrigidas, então **`package.json` não mudou** — nem foi preciso recorrer a `resolutions`.

## Diff

Apenas `yarn.lock`, 6 linhas — nenhuma mudança de código.

## Validação local

Rodada após cada um dos dois bumps:

- `yarn test` — 170 testes, 19 arquivos, todos passando
- `yarn lint` — limpo
- `yarn build` — build de produção completo (preset Netlify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)