### PR TITLE
chore(deps): corrige 12 alertas de segurança em dependências transitivas

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7053,9 +7053,9 @@ tar-stream@^3.0.0:
     streamx "^2.15.0"
 
 tar@^7.4.0:
-  version "7.5.16"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.16.tgz#f11e063afed4554f758049d082909e37d6b53ced"
-  integrity sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7020,9 +7020,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 svgo@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.1.tgz#c82dacd04ee9f1d55cd4e0b7f9a214c86670e3ee"
-  integrity sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.2.tgz#a62246f0a9d671c0314d04f3cc15f78b1bd0667f"
+  integrity sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==
   dependencies:
     commander "^11.1.0"
     css-select "^5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,9 +6738,9 @@ shebang-regex@^3.0.0:
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
-  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.10.0.tgz#482033e192e4f5c07151521ffa03400ec71b1b0f"
+  integrity sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==
 
 siginfo@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4420,9 +4420,9 @@ fast-string-width@^3.0.2:
     fast-string-truncated-width "^3.0.2"
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fast-wrap-ansi@^0.1.3:
   version "0.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5059,9 +5059,9 @@ js-tokens@^9.0.1:
   integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
 
 js-yaml@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,10 +5526,10 @@ muggle-string@^0.4.1:
   resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.4.1.tgz#3b366bd43b32f809dc20659534dd30e7c8a0d328"
   integrity sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==
 
-nanoid@^3.3.12:
-  version "3.3.12"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
-  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 nanotar@^0.3.0:
   version "0.3.0"
@@ -6329,11 +6329,11 @@ postcss-value-parser@^4.2.0:
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.5.14, postcss@^8.5.15, postcss@^8.5.6:
-  version "8.5.15"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
-  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
+  version "8.5.24"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.24.tgz#01d8b032451e1b9ec41ae66eaf02843f42a720d2"
+  integrity sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,16 +3166,16 @@ boolbase@^1.0.0:
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 brace-expansion@^2.0.1, brace-expansion@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.3.tgz#1bf69aacdf6a4380ca17c284d9f928d4aa6401bc"
+  integrity sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==
   dependencies:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Contexto

Ao longo da última semana o Dependabot acumulou **12 alertas de segurança abertos** neste repositório — entre eles uma **crítica** (`tar`, CVE-2026-59873) e nove de severidade **alta**. Todos em dependências **transitivas**, o que explica por que nenhum aparecia no `package.json`: chegaram através do toolchain de build (Nuxt, Vite, PostCSS, ESLint) sem que nenhuma dependência direta do projeto tivesse mudado.

Três desses alertas (`brace-expansion`) **não geraram PR automático** do Dependabot, então ficariam abertos por tempo indeterminado se ninguém agisse manualmente — foi o que motivou este trabalho.

Nenhuma das vulnerabilidades está em caminho de request do site: são DoS por consumo de CPU/memória em parsers (tar, YAML, SVG, URI, brace-expansion, PostCSS) e injeção de comando no `shell-quote`, todas em ferramentas de build. O risco prático para o Pedala Sampa em produção era baixo — mas o custo de fechar foi mínimo e mantém a superfície limpa.

## O que muda

Apenas o `yarn.lock`. **Zero mudança de código, zero mudança no `package.json`** — todos os ranges já permitiam as versões corrigidas.

| Pacote | Versão | Alertas | Pior severidade |
|---|---|---|---|
| `tar` | 7.5.16 → 7.5.22 | 258, 259, 260, 261 | **crítica** (CVE-2026-59873) |
| `postcss` | 8.5.15 → 8.5.24 | 264 | alta |
| `brace-expansion` | 2.1.1 → 2.1.3 | 263 | alta (CVE-2026-13149) |
| `brace-expansion` | 5.0.6 → 5.0.8 | 253, 266 | alta (CVE-2026-13149, CVE-2026-14257) |
| `shell-quote` | 1.8.4 → 1.10.0 | 257 | alta (CVE-2026-13311) |
| `fast-uri` | 3.1.2 → 3.1.4 | 255, 256 | alta |
| `js-yaml` | 4.2.0 → 4.3.0 | 262 | alta (CVE-2026-59869) |
| `svgo` | 4.0.1 → 4.0.2 | 254 | alta |

Arrastado junto, sem alerta associado: `nanoid` 3.3.12 → 3.3.16, exigido pelo `postcss@8.5.24`.

## Commits incluídos

Sete PRs já revisados e mergeados na `develop`:

- #106 `svgo` · #107 `fast-uri` · #108 `shell-quote` · #109 `tar` · #110 `js-yaml` — PRs automáticos do Dependabot, lock-only
- #111 `postcss` — PR automático do Dependabot, lock-only
- #112 `brace-expansion` — **manual**, cobrindo os três alertas que o Dependabot não tratou sozinho

Sobre o #112: `brace-expansion` aparece em duas entradas independentes do lockfile (`^5.0.5` via `minimatch@10.2.5`, e `^2.0.1`/`^2.0.2` via vários consumidores do toolchain). Como o Yarn 1 não faz `upgrade` de transitivas, as duas entradas foram reresolvidas removendo-as do lockfile e reinstalando — sem precisar recorrer a `resolutions`, que deixaria dívida permanente no `package.json`.

## Estado dos alertas

11 dos 12 já constam como `fixed`. O alerta **266** segue `open` por um resíduo do lado do GitHub: foi criado às 13:02 e o merge que o corrige entrou às 13:09, então ficou fora do ciclo de reavaliação que fechou os outros dois `brace-expansion` no mesmo instante. O SBOM do repositório já reporta `5.0.8` — a versão que o próprio advisory exige. Deve fechar sozinho no próximo ciclo; não há trabalho pendente de código.

## Test plan

Validação automatizada — rodada localmente após **cada** um dos dois bumps do #112, e replicada pelo CI em todos os sete PRs:

- [x] `yarn test` — 170 testes, 19 arquivos, todos passando
- [x] `yarn lint` — limpo
- [x] `yarn build` — build de produção completo (preset Netlify)
- [x] CI verde nos sete PRs (`quality`, `commitlint`, deploy preview do Netlify)

Smoke test manual sugerido no deploy preview, cobrindo o que o toolchain afetado toca (SVG via `svgo`, CSS via `postcss`, empacotamento via `tar`):

- [ ] Home carrega e o mapa renderiza com os marcadores de grupos
- [ ] Ícones e SVGs aparecem corretamente (pipeline do `svgo`)
- [ ] Estilos aplicados sem quebra de layout, nos temas claro e escuro (pipeline do `postcss`)
- [ ] Formulário de sugestão (`/contribute`) envia e responde
- [ ] Formulário de feedback (`/about`) envia e responde
- [ ] Páginas `/privacy` e `/terms` renderizam

🤖 Generated with [Claude Code](https://claude.com/claude-code)