### PR TITLE
docs: série de 5 posts para LinkedIn com carrosséis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ sw.*
 
 # Local Netlify folder
 .netlify
+
+# Imagens geradas da série do LinkedIn (~9 MB, regeráveis via docs/marketing/linkedin/README.md)
+docs/marketing/linkedin/exports/

--- a/docs/marketing/linkedin/README.md
+++ b/docs/marketing/linkedin/README.md
@@ -11,7 +11,7 @@ arquitetura → a comunidade → o processo.
 | # | Post | Gancho | Imagem |
 |---|---|---|---|
 | 1 | [O produto](post-1-produto.md) | "Descobrir qual grupo passa perto de você não existia em lugar nenhum" | 2 screenshots |
-| 2 | [Design & frontend](post-2-design.md) | "clip-path recorta o box-shadow" — 7 commits para um hover | carrossel, 7 slides |
+| 2 | [O design system](post-2-design.md) | "8 cores. E não entra uma nona." | carrossel, 6 slides |
 | 3 | [Arquitetura](post-3-arquitetura.md) | "Prerender é rápido. Também é uma foto congelada." | carrossel, 6 slides |
 | 4 | [Comunidade & segurança](post-4-comunidade.md) | "Um formulário aberto na internet é um alvo" | carrossel, 7 slides |
 | 5 | [Processo & entrega](post-5-processo.md) | "4 anos parado. 5 versões em 8 dias." | carrossel, 7 slides |
@@ -44,7 +44,7 @@ cd docs/marketing/linkedin
 # 1440×900 (desktop) e 390×844 (mobile), nos dois temas
 
 # slides dos carrosséis — 1080×1350 (4:5), o formato que mais ocupa a tela no feed
-for deck in 2:7 3:6 4:7 5:7; do
+for deck in 2:6 3:6 4:7 5:7; do
   post="${deck%%:*}"; count="${deck##*:}"
   for n in $(seq 1 "$count"); do
     google-chrome --headless --disable-gpu --hide-scrollbars \

--- a/docs/marketing/linkedin/README.md
+++ b/docs/marketing/linkedin/README.md
@@ -14,7 +14,7 @@ arquitetura → a comunidade → o processo.
 | 2 | [O design system](post-2-design.md) | "8 cores. E não entra uma nona." | carrossel, 6 slides |
 | 3 | [Arquitetura](post-3-arquitetura.md) | "Prerender é rápido. Também é uma foto congelada." | carrossel, 6 slides |
 | 4 | [Comunidade & segurança](post-4-comunidade.md) | "Um formulário aberto na internet é um alvo" | carrossel, 7 slides |
-| 5 | [Processo & entrega](post-5-processo.md) | "4 anos parado. 5 versões em 8 dias." | carrossel, 7 slides |
+| 5 | [Processo & entrega](post-5-processo.md) | "5 versões em 8 dias. Nenhum changelog escrito à mão." | carrossel, 7 slides |
 
 ## Cadência sugerida
 

--- a/docs/marketing/linkedin/README.md
+++ b/docs/marketing/linkedin/README.md
@@ -1,0 +1,99 @@
+# Série de posts para LinkedIn
+
+Cinco posts temáticos sobre o Pedala Sampa. Ênfase **70% técnico / 30% produto** — o objetivo é
+vitrine de engenharia frontend, com o produto servindo de prova de entrega.
+
+Cada post se sustenta sozinho, mas juntos formam uma jornada: o problema → o design → a
+arquitetura → a comunidade → o processo.
+
+## A série
+
+| # | Post | Gancho | Imagem |
+|---|---|---|---|
+| 1 | [O produto](post-1-produto.md) | "Descobrir qual grupo passa perto de você não existia em lugar nenhum" | 2 screenshots |
+| 2 | [Design & frontend](post-2-design.md) | "clip-path recorta o box-shadow" — 7 commits para um hover | carrossel, 7 slides |
+| 3 | [Arquitetura](post-3-arquitetura.md) | "Prerender é rápido. Também é uma foto congelada." | carrossel, 6 slides |
+| 4 | [Comunidade & segurança](post-4-comunidade.md) | "Um formulário aberto na internet é um alvo" | carrossel, 7 slides |
+| 5 | [Processo & entrega](post-5-processo.md) | "4 anos parado. 5 versões em 8 dias." | carrossel, 7 slides |
+
+## Cadência sugerida
+
+Um post por semana, terça ou quarta, entre 8h e 10h. Ordem 1 → 5.
+
+Do post 2 em diante, abra referenciando o anterior ("no post passado falei do mapa; hoje…").
+O post 5 fecha com o convite para contribuir.
+
+## Estrutura de cada arquivo
+
+1. **Texto para colar** — já quebrado em parágrafos curtos, sem markdown (o LinkedIn não renderiza).
+2. **Variante curta** — versão enxuta, caso queira testar o formato.
+3. **Imagens / carrossel** — o que cada slide mostra.
+4. **Fontes** — o arquivo ou commit que sustenta cada afirmação técnica do post.
+
+A seção de fontes existe porque **post com número errado sobre o próprio projeto é o pior
+resultado possível**. Confira antes de publicar.
+
+## Imagens
+
+Os PNGs ficam em `exports/` e **não são versionados** (são ~9 MB). Para regerar:
+
+```bash
+cd docs/marketing/linkedin
+
+# screenshots do site: capturados manualmente em produção,
+# 1440×900 (desktop) e 390×844 (mobile), nos dois temas
+
+# slides dos carrosséis — 1080×1350 (4:5), o formato que mais ocupa a tela no feed
+for deck in 2:7 3:6 4:7 5:7; do
+  post="${deck%%:*}"; count="${deck##*:}"
+  for n in $(seq 1 "$count"); do
+    google-chrome --headless --disable-gpu --hide-scrollbars \
+      --window-size=1080,1350 --virtual-time-budget=8000 \
+      --screenshot="exports/post-${post}-slide-$(printf '%02d' "$n").png" \
+      "file://$PWD/slides/post-${post}-slides.html?slide=${n}"
+  done
+done
+```
+
+Os slides vivem em `slides/*.html` e usam `slides/_base.css`, cujos tokens vêm do design system
+do próprio projeto (`docs/redesign/design_handoff_pedala_sampa/design-system/`), tema Ciclovia.
+Assim o carrossel parece parte da marca, e não um template genérico.
+
+Abrir um deck com `?slide=N` exibe só aquele slide, com a página em exatamente 1080×1350 — é o que
+permite a captura em lote acima.
+
+### Regras de layout dos slides
+
+Herdadas do design system, e vale mantê-las ao editar:
+
+- nenhuma cor fora dos 8 tokens (variações derivadas, não hex novo)
+- sombra dura deslocada, **blur zero**
+- CTA / destaque em paralelogramo via `clip-path`
+- card com trilho verde de 5px
+- sem gradiente, sem card pill, sem emoji como elemento de UI
+- **corpo de texto nunca abaixo de 26px** — carrossel é lido no celular
+
+### Verificação antes de exportar
+
+Os dois checks que já pegaram problemas reais (uma célula com texto invisível e notas de rodapé a
+2,7:1). Rode no console com o deck aberto:
+
+```js
+// 1) overflow: nenhum slide pode estourar os 1350px
+document.querySelectorAll('.slide').forEach(s =>
+  console.log(s.dataset.n, s.scrollHeight - s.clientHeight)
+)
+```
+
+Para contraste, sirva a pasta (`python3 -m http.server`) e compare a cor de cada nó de texto com o
+fundo efetivo — o alvo é **≥ 3:1**. O caso que escapa fácil: um card de fundo claro dentro de um
+slide `.slide--dark` herda texto claro e some.
+
+## Checklist de publicação
+
+- [ ] Conferir os números do post na seção **Fontes** (contagem de commits e de grupos no mapa mudam)
+- [ ] Colar no compositor do LinkedIn e ver onde cai o "…ver mais" — o gancho precisa estar **acima** do corte
+- [ ] Conferir se os links abrem (site e repositório)
+- [ ] Subir as imagens na ordem
+- [ ] No carrossel, o LinkedIn pede PDF — juntar os PNGs na ordem antes de subir
+- [ ] Responder comentários nas primeiras 2 horas (é o que a plataforma premia)

--- a/docs/marketing/linkedin/post-1-produto.md
+++ b/docs/marketing/linkedin/post-1-produto.md
@@ -27,7 +27,7 @@ Porque um mapa de grupos de pedal só continua verdadeiro se quem pedala puder c
 
 O projeto é open source e roda em Nuxt 3, com Hygraph de CMS e deploy na Netlify.
 
-Nos próximos posts eu abro o capô: o design system que faz o site parecer sinalização de rua, por que um site prerenderizado precisa de um webhook para funcionar, como aceitar contribuição de desconhecido sem virar alvo de spam, e como saíram 5 versões em 8 dias.
+Nos próximos posts eu abro o capô: o design system de 8 cores que sustenta a interface, por que um site prerenderizado precisa de um webhook para funcionar, como aceitar contribuição de desconhecido sem virar alvo de spam, e como saíram 5 versões em 8 dias.
 
 Se você pedala em SP, dá uma olhada — e me conta qual grupo está faltando.
 

--- a/docs/marketing/linkedin/post-1-produto.md
+++ b/docs/marketing/linkedin/post-1-produto.md
@@ -1,0 +1,85 @@
+# Post 1 — O produto (abertura da série)
+
+**Tema**: o problema real e o produto que resolve.
+**Objetivo**: porta de entrada. É o post mais acessível da série — abre o caminho para os 4 seguintes.
+**Imagem**: `exports/01-home-desktop-ciclovia.png` (principal) + `exports/02-home-desktop-noturno.png`.
+
+---
+
+## Texto para colar
+
+```
+São Paulo tem dezenas de grupos de pedal saindo toda semana.
+
+Descobrir qual passa perto de você, no dia que você pode e no ritmo que você aguenta? Isso não existia em lugar nenhum.
+
+A informação está espalhada em stories que somem em 24h, grupos de WhatsApp fechados e perfis que postam o ponto de encontro em cima da hora. Se você não conhece alguém que já pedala, você simplesmente não entra.
+
+Então eu construí o Pedala Sampa: um mapa colaborativo dos grupos de pedal da cidade.
+
+Você abre e vê os pontos de saída no mapa. Filtra por dia da semana, nível, distância, período do dia e ritmo — combinados. Clica num grupo e vê o endereço exato de onde ele sai, o horário e o link de contato.
+
+Sem login. Sem cadastro. Sem app para instalar.
+
+E a parte que mais me importa: qualquer pessoa pode sugerir um grupo que está faltando, corrigir um dado errado ou adicionar um novo horário. Também sem criar conta. Toda contribuição passa por revisão antes de ir ao ar.
+
+Porque um mapa de grupos de pedal só continua verdadeiro se quem pedala puder consertá-lo.
+
+O projeto é open source e roda em Nuxt 3, com Hygraph de CMS e deploy na Netlify.
+
+Nos próximos posts eu abro o capô: o design system que faz o site parecer sinalização de rua, por que um site prerenderizado precisa de um webhook para funcionar, como aceitar contribuição de desconhecido sem virar alvo de spam, e como saíram 5 versões em 8 dias.
+
+Se você pedala em SP, dá uma olhada — e me conta qual grupo está faltando.
+
+🔗 https://pedalasampa.netlify.app
+
+#frontend #nuxt #vuejs #opensource #ciclismo
+```
+
+---
+
+## Variante curta (~600 caracteres)
+
+```
+São Paulo tem dezenas de grupos de pedal saindo toda semana. Descobrir qual passa perto de você, no dia que você pode e no ritmo que você aguenta? Isso não existia.
+
+A informação vive em stories que somem e grupos de WhatsApp fechados. Quem não conhece alguém, não entra.
+
+Construí o Pedala Sampa: mapa colaborativo dos grupos de pedal da cidade. Filtra por dia, nível, distância, período e ritmo. Sem login, sem app.
+
+E qualquer pessoa pode sugerir um grupo que falta ou corrigir um dado errado — também sem conta.
+
+Open source, em Nuxt 3.
+
+🔗 https://pedalasampa.netlify.app
+
+#frontend #nuxt #opensource
+```
+
+---
+
+## Imagens
+
+| Ordem | Arquivo | Legenda sugerida |
+|---|---|---|
+| 1 | `exports/01-home-desktop-ciclovia.png` | O mapa com os pontos de saída e o carrossel de grupos |
+| 2 | `exports/02-home-desktop-noturno.png` | O mesmo mapa no tema Noturno |
+
+Se for publicar uma imagem só, use a **01**. É a tela que explica o produto sem legenda.
+
+---
+
+## Fontes
+
+| Afirmação | Onde se verifica |
+|---|---|
+| Filtros por dia, nível, distância, período e ritmo | `lib/group-filters.ts`, `lib/filter-options.ts` |
+| Sem login / sem cadastro | Não há rota de auth; `pages/` tem 10 rotas, nenhuma de sessão |
+| 4 fluxos de contribuição sem conta | `pages/contribute/*`, `server/api/suggestions.post.ts` |
+| Revisão antes de ir ao ar | Sugestões entram como `PENDING` em stage DRAFT — `docs/curation.md` |
+| Nuxt 3 + Hygraph + Netlify | `package.json`, `nuxt.config.ts` (`nitro.preset: 'netlify'`) |
+| Repositório público | https://github.com/adams-alves-dev/pedala-sampa |
+
+⚠️ **Conferir antes de publicar**: o número de grupos no mapa é dado vivo (eram 14 na captura de
+29/07/2026). O texto do post não cita o número justamente para não envelhecer — se você quiser
+citá-lo, confira no site primeiro.

--- a/docs/marketing/linkedin/post-2-design.md
+++ b/docs/marketing/linkedin/post-2-design.md
@@ -1,53 +1,50 @@
-# Post 2 — Design & frontend
+# Post 2 — O design system
 
-**Tema**: design system próprio, dois temas, e um bug de CSS que levou duas tentativas erradas.
-**Objetivo**: o post mais "frontend puro" da série. É o que melhor vende competência técnica de CSS.
-**Imagem**: carrossel de 7 slides (`slides/post-2-slides.html`).
+**Tema**: um design system pequeno e fechado, e o que a restrição resolve.
+**Objetivo**: mostrar disciplina de frontend sem depender de nenhuma leitura estética do site.
+**Imagem**: carrossel de 6 slides (`slides/post-2-slides.html`).
 
 ---
 
 ## Texto para colar
 
 ```
-O redesign do meu projeto não começou num Figma. Começou num design system escrito em HTML e CSS — com uma regra explícita: recriar fielmente, sem copiar uma linha do protótipo para dentro do Nuxt.
+O design system do meu projeto tem 8 cores.
 
-A direção visual tem nome: wayfinding. Sinalização urbana.
+Oito. E a regra é que não entra uma nona.
 
-Tinta asfalto sobre concreto. Verde de ciclovia para seleção. Amarelo de placa de trânsito para as ações principais. Superfícies anguladas, tipografia grotesca, nada de gradiente.
+Precisou de um tom que não existe? Deriva em oklch a partir de um dos 8 — não inventa um hex novo. É uma restrição chata de propósito, porque é ela que impede um sistema de virar uma paleta de 40 cores em três meses, com quatro cinzas quase iguais que ninguém sabe mais quando usar.
 
-O sistema inteiro cabe em 8 cores. E a regra é dura: nenhum tom fora dessas 8. Precisou de uma variação? Deriva em oklch a partir do token, não inventa um hex novo. É isso que impede um design system de virar uma paleta de 40 cores em três meses.
+Outra decisão que mudou meu jeito de trabalhar: o design não chegou como Figma. Chegou como um design system em HTML e CSS — tokens, componentes e uma página de showcase, tudo funcionando no browser.
 
-Alguns detalhes que dão identidade:
+Com uma regra explícita junto: recriar fielmente em componentes Vue idiomáticos, sem copiar o HTML e o JS do protótipo para dentro do Nuxt.
 
-→ Sombra dura, deslocada, sem blur nenhum. Parece placa impressa, não Material Design.
-→ CTAs cortados em paralelogramo com clip-path.
-→ Card com trilho verde de 5px na lateral.
-→ Pin do mapa em teardrop numerado — o selecionado cresce e vira amarelo.
+Isso resolve o problema clássico do handoff. Não tem "mas no Figma o espaçamento era outro", porque a referência é executável — dá para abrir e inspecionar. E não tem protótipo virando código de produção por preguiça, porque portar é obrigatório.
 
-E dois temas: Ciclovia (claro) e Noturno (escuro). O Noturno não troca só as cores da interface — ele troca os tiles do mapa também. Interface escura com mapa claro estourando no meio da tela seria pior que não ter tema escuro.
+O que o sistema define:
 
-Agora o bug.
+→ 8 cores core, mais tons derivados com papel semântico
+→ Escala tipográfica fechada, de 11px a um clamp que chega a 80px
+→ Espaçamento em base 4px
+→ Dois raios de borda. Dois.
+→ Duas sombras: a de placa, 4px 4px 0 sem blur nenhum, e a de painel, essa sim difusa
 
-O CTA amarelo tem clip-path, para virar paralelogramo. E o hover dele simplesmente não aparecia.
+Os temas são a parte que mais me agrada, porque não são um tema escuro pregado em cima. Cada tema é só um override dos mesmos tokens. Trocar de Ciclovia para Noturno não passa por nenhum componente — passa por um bloco de variáveis CSS.
 
-Descoberta: clip-path RECORTA o box-shadow. A sombra era desenhada e cortada no mesmo frame. Sobrava só o deslocamento de 2px, imperceptível.
+E o tema escuro troca os tiles do mapa junto. Interface escura com um mapa claro estourando no meio da tela é pior do que não ter tema escuro.
 
-Primeira correção: trocar box-shadow por filter: drop-shadow(), que é aplicado depois do recorte.
+A parte que quase ninguém conta sobre design system: o handoff explorou 6 temas e 5 pareamentos de fonte. Foram para produção 2 temas e 1 par.
 
-Isso também falhou. drop-shadow não renderiza em elemento com clip-path em alguns navegadores. De novo, só o movimento aparecia.
+Também tinha um painel de tweaks para ajustar tokens ao vivo. Não foi.
 
-Solução final: parar de pedir sombra ao browser e construir a camada na mão. ::after é a face amarela, ::before é um bloco verde escondido atrás dela. No hover, a placa salta e o bloco desliza para fora. isolation: isolate escopa o z-index negativo.
+Explorar seis e escolher dois não é desperdício — é como você descobre que dois bastam. O desperdício seria implementar os seis porque já estavam prontos.
 
-Sem filter. Sem box-shadow recortado. Funciona em todo navegador.
-
-A lição que fica: recorte e sombra vivem em estágios diferentes do pipeline de pintura. Quando você corta um elemento, você está cortando tudo que ele desenha — inclusive o que você queria que vazasse para fora dele.
-
-Foram 7 commits para um estado de hover. Não me arrependo de nenhum.
+Sistema pequeno não é sistema pobre. É sistema que alguém consegue seguir sem consultar documentação toda vez.
 
 🔗 O site: https://pedalasampa.netlify.app
 🔗 O código: https://github.com/adams-alves-dev/pedala-sampa
 
-#css #frontend #designsystem #vuejs #nuxt
+#designsystem #css #frontend #vuejs #nuxt
 ```
 
 ---
@@ -55,34 +52,33 @@ Foram 7 commits para um estado de hover. Não me arrependo de nenhum.
 ## Variante curta (~700 caracteres)
 
 ```
-Bug de CSS que me custou 7 commits:
+O design system do meu projeto tem 8 cores. E a regra é que não entra uma nona.
 
-Meu CTA amarelo é cortado em paralelogramo com clip-path. O hover dele não aparecia.
+Precisou de um tom novo? Deriva em oklch a partir dos 8. É chato de propósito — é o que impede o sistema de virar uma paleta de 40 cores com quatro cinzas quase iguais.
 
-Motivo: clip-path RECORTA o box-shadow. A sombra era desenhada e cortada no mesmo frame.
+Junto: escala tipográfica fechada, espaçamento base 4px, dois raios de borda, duas sombras.
 
-Tentativa 1 — trocar por filter: drop-shadow(), aplicado depois do recorte. Falhou: drop-shadow não renderiza sobre clip-path em alguns navegadores.
+E os temas são só override dos mesmos tokens. Trocar de claro para escuro não passa por nenhum componente — passa por um bloco de variáveis CSS.
 
-Solução — parar de pedir sombra ao browser. ::after é a face amarela, ::before é um bloco verde atrás. No hover a placa salta e o bloco desliza.
+O handoff explorou 6 temas. Foram para produção 2.
 
-Recorte e sombra vivem em estágios diferentes do pipeline de pintura. Ao cortar o elemento, você corta tudo que ele desenha.
+Sistema pequeno não é sistema pobre. É sistema que alguém consegue seguir sem consultar documentação toda vez.
 
-#css #frontend #webdev
+#designsystem #css #frontend
 ```
 
 ---
 
-## Carrossel — 7 slides
+## Carrossel — 6 slides
 
 | # | Conteúdo |
 |---|---|
-| 1 | **Capa** — "Um design system que parece placa de rua" + subtítulo "e o bug de CSS que me custou 7 commits" |
-| 2 | **Os 8 tokens** — swatches com nome e hex |
-| 3 | **Ciclovia × Noturno** — as duas capturas reais lado a lado, com destaque "os tiles do mapa também mudam" |
-| 4 | **Anatomia do CTA** — o paralelogramo, o clip-path e a sombra dura sem blur |
-| 5 | **O bug** — "clip-path recorta box-shadow" com diagrama antes/depois |
-| 6 | **As duas tentativas** — drop-shadow falhou; pseudo-elementos funcionaram (com o CSS) |
-| 7 | **Fecho** — a lição + links |
+| 1 | **Capa** — "Um design system de 8 cores. E a regra é que não entra uma nona." |
+| 2 | **Os 8 tokens** — swatches com nome e hex + a regra do oklch |
+| 3 | **O que mais o sistema fecha** — tipografia, espaçamento, raios, sombras |
+| 4 | **Tema é override de token** — Ciclovia × Noturno (capturas reais), incluindo os tiles |
+| 5 | **O corte** — 6 temas e 5 pares de fonte explorados; 2 temas e 1 par no ar |
+| 6 | **Fecho** — "sistema pequeno não é sistema pobre" + links |
 
 ---
 
@@ -90,14 +86,20 @@ Recorte e sombra vivem em estágios diferentes do pipeline de pintura. Ao cortar
 
 | Afirmação | Onde se verifica |
 |---|---|
-| Direção "wayfinding / sinalização urbana" | `docs/redesign/design_handoff_pedala_sampa/README.md` |
-| Regra "recriar fielmente, não copiar o protótipo" | Spec do handoff, `docs/redesign/2026-06-02-handoff-implementation-spec.md` |
 | 8 tokens core | `design-system/colors_and_type.css` — asphalt `#1A120B`, concrete `#E8E0D0`, paper `#FFF8EE`, bike-green `#00796B`, sign-yellow `#FFB300`, alert-red `#E53935`, transit-blue `#1565C0`, border `#C8BFA8` |
-| Tema Ciclovia | `design-system/themes.css` — asphalt `#11271C`, concrete `#DCE7DA`, paper `#F4F9F0`, green `#1F8A4C`, yellow `#F2B33A` |
-| Derivar novos tons em oklch | Don'ts do `design-system/README.md` |
-| Tiles trocam no tema escuro | `components/map/MapTileLayer.vue`; **confirmado ao vivo**: o toggle troca a URL para `basemaps.cartocdn.com/dark_all/...` |
-| Archivo + Hanken Grotesk | `nuxt.config.ts` (Google Fonts) e `--font-display` / `--font-body` |
-| clip-path recorta box-shadow | commit `26d9ebd` — *"clip-path RECORTA o box-shadow — a sombra do hover era desenhada e cortada na hora, sobrando só o deslocamento"* |
-| drop-shadow também falhou | commit `c53177d` — *"filter: drop-shadow não renderiza em elemento com clip-path em alguns navegadores"* |
-| Solução por pseudo-elementos | commit `c53177d` — `::after` face amarela, `::before` bloco verde, `isolation: isolate` |
-| 7 commits | `1a54353`, `fe6569b`, `26d9ebd`, `d028842`, `ee14559`, `c53177d`, `a1b9184` |
+| "Nunca invente cores/fontes fora destes tokens" | `design_handoff_pedala_sampa/README.md:29` |
+| Derivar novos tons em oklch | `design-system/README.md:57` — *"New shades should be derived in oklch from the core palette"* |
+| Handoff em HTML/CSS, não Figma | `docs/redesign/design_handoff_pedala_sampa/` — protótipo + `Design System.html` |
+| Regra "recriar fielmente, não copiar o protótipo" | `docs/redesign/2026-06-02-handoff-implementation-spec.md` |
+| Escala tipográfica 11px → clamp 80px | `colors_and_type.css:38-45` — `--text-xs` `0.6875rem` … `--text-3xl` `clamp(2.25rem, 8vw, 5rem)` |
+| Espaçamento base 4px, dois raios | `README.md:65` — `--space-1`=4 … `--space-16`=64; `--radius-sm` 4px, `--radius-md` 6px |
+| Duas sombras | `README.md:65` e `:194` — placa `4px 4px 0` **sem blur**; painel `0 18px 50px rgb(26 18 11 / 18%)` **com** blur |
+| Tema = override de token | `design-system/themes.css` — cada tema é um bloco `[data-theme='…']` redefinindo as mesmas variáveis |
+| Tema escuro troca os tiles | `components/map/MapTileLayer.vue`; **confirmado ao vivo**: o toggle troca a URL para `basemaps.cartocdn.com/dark_all/...` |
+| 6 temas explorados, 2 em produção | `themes.css` — `asfalto`, `ciclovia`, `sol`, `metro`, `coral`, `noturno`; só Ciclovia e Noturno viraram light/dark no app |
+| 5 pares de fonte, 1 em produção | `design-system/themes.css`; produção usa Archivo + Hanken Grotesk (`nuxt.config.ts`) |
+| Painel de tweaks descartado | Decisão registrada no handoff: *"Painel de Tweaks: não vai para produção"* |
+
+⚠️ **Precisão que vale manter**: a regra "sem blur" vale só para a **sombra de placa**. A sombra de
+painel (`0 18px 50px`) é difusa de propósito. O texto do post já faz essa distinção — não
+simplifique para "o sistema não usa blur", porque seria falso.

--- a/docs/marketing/linkedin/post-2-design.md
+++ b/docs/marketing/linkedin/post-2-design.md
@@ -1,0 +1,103 @@
+# Post 2 — Design & frontend
+
+**Tema**: design system próprio, dois temas, e um bug de CSS que levou duas tentativas erradas.
+**Objetivo**: o post mais "frontend puro" da série. É o que melhor vende competência técnica de CSS.
+**Imagem**: carrossel de 7 slides (`slides/post-2-slides.html`).
+
+---
+
+## Texto para colar
+
+```
+O redesign do meu projeto não começou num Figma. Começou num design system escrito em HTML e CSS — com uma regra explícita: recriar fielmente, sem copiar uma linha do protótipo para dentro do Nuxt.
+
+A direção visual tem nome: wayfinding. Sinalização urbana.
+
+Tinta asfalto sobre concreto. Verde de ciclovia para seleção. Amarelo de placa de trânsito para as ações principais. Superfícies anguladas, tipografia grotesca, nada de gradiente.
+
+O sistema inteiro cabe em 8 cores. E a regra é dura: nenhum tom fora dessas 8. Precisou de uma variação? Deriva em oklch a partir do token, não inventa um hex novo. É isso que impede um design system de virar uma paleta de 40 cores em três meses.
+
+Alguns detalhes que dão identidade:
+
+→ Sombra dura, deslocada, sem blur nenhum. Parece placa impressa, não Material Design.
+→ CTAs cortados em paralelogramo com clip-path.
+→ Card com trilho verde de 5px na lateral.
+→ Pin do mapa em teardrop numerado — o selecionado cresce e vira amarelo.
+
+E dois temas: Ciclovia (claro) e Noturno (escuro). O Noturno não troca só as cores da interface — ele troca os tiles do mapa também. Interface escura com mapa claro estourando no meio da tela seria pior que não ter tema escuro.
+
+Agora o bug.
+
+O CTA amarelo tem clip-path, para virar paralelogramo. E o hover dele simplesmente não aparecia.
+
+Descoberta: clip-path RECORTA o box-shadow. A sombra era desenhada e cortada no mesmo frame. Sobrava só o deslocamento de 2px, imperceptível.
+
+Primeira correção: trocar box-shadow por filter: drop-shadow(), que é aplicado depois do recorte.
+
+Isso também falhou. drop-shadow não renderiza em elemento com clip-path em alguns navegadores. De novo, só o movimento aparecia.
+
+Solução final: parar de pedir sombra ao browser e construir a camada na mão. ::after é a face amarela, ::before é um bloco verde escondido atrás dela. No hover, a placa salta e o bloco desliza para fora. isolation: isolate escopa o z-index negativo.
+
+Sem filter. Sem box-shadow recortado. Funciona em todo navegador.
+
+A lição que fica: recorte e sombra vivem em estágios diferentes do pipeline de pintura. Quando você corta um elemento, você está cortando tudo que ele desenha — inclusive o que você queria que vazasse para fora dele.
+
+Foram 7 commits para um estado de hover. Não me arrependo de nenhum.
+
+🔗 O site: https://pedalasampa.netlify.app
+🔗 O código: https://github.com/adams-alves-dev/pedala-sampa
+
+#css #frontend #designsystem #vuejs #nuxt
+```
+
+---
+
+## Variante curta (~700 caracteres)
+
+```
+Bug de CSS que me custou 7 commits:
+
+Meu CTA amarelo é cortado em paralelogramo com clip-path. O hover dele não aparecia.
+
+Motivo: clip-path RECORTA o box-shadow. A sombra era desenhada e cortada no mesmo frame.
+
+Tentativa 1 — trocar por filter: drop-shadow(), aplicado depois do recorte. Falhou: drop-shadow não renderiza sobre clip-path em alguns navegadores.
+
+Solução — parar de pedir sombra ao browser. ::after é a face amarela, ::before é um bloco verde atrás. No hover a placa salta e o bloco desliza.
+
+Recorte e sombra vivem em estágios diferentes do pipeline de pintura. Ao cortar o elemento, você corta tudo que ele desenha.
+
+#css #frontend #webdev
+```
+
+---
+
+## Carrossel — 7 slides
+
+| # | Conteúdo |
+|---|---|
+| 1 | **Capa** — "Um design system que parece placa de rua" + subtítulo "e o bug de CSS que me custou 7 commits" |
+| 2 | **Os 8 tokens** — swatches com nome e hex |
+| 3 | **Ciclovia × Noturno** — as duas capturas reais lado a lado, com destaque "os tiles do mapa também mudam" |
+| 4 | **Anatomia do CTA** — o paralelogramo, o clip-path e a sombra dura sem blur |
+| 5 | **O bug** — "clip-path recorta box-shadow" com diagrama antes/depois |
+| 6 | **As duas tentativas** — drop-shadow falhou; pseudo-elementos funcionaram (com o CSS) |
+| 7 | **Fecho** — a lição + links |
+
+---
+
+## Fontes
+
+| Afirmação | Onde se verifica |
+|---|---|
+| Direção "wayfinding / sinalização urbana" | `docs/redesign/design_handoff_pedala_sampa/README.md` |
+| Regra "recriar fielmente, não copiar o protótipo" | Spec do handoff, `docs/redesign/2026-06-02-handoff-implementation-spec.md` |
+| 8 tokens core | `design-system/colors_and_type.css` — asphalt `#1A120B`, concrete `#E8E0D0`, paper `#FFF8EE`, bike-green `#00796B`, sign-yellow `#FFB300`, alert-red `#E53935`, transit-blue `#1565C0`, border `#C8BFA8` |
+| Tema Ciclovia | `design-system/themes.css` — asphalt `#11271C`, concrete `#DCE7DA`, paper `#F4F9F0`, green `#1F8A4C`, yellow `#F2B33A` |
+| Derivar novos tons em oklch | Don'ts do `design-system/README.md` |
+| Tiles trocam no tema escuro | `components/map/MapTileLayer.vue`; **confirmado ao vivo**: o toggle troca a URL para `basemaps.cartocdn.com/dark_all/...` |
+| Archivo + Hanken Grotesk | `nuxt.config.ts` (Google Fonts) e `--font-display` / `--font-body` |
+| clip-path recorta box-shadow | commit `26d9ebd` — *"clip-path RECORTA o box-shadow — a sombra do hover era desenhada e cortada na hora, sobrando só o deslocamento"* |
+| drop-shadow também falhou | commit `c53177d` — *"filter: drop-shadow não renderiza em elemento com clip-path em alguns navegadores"* |
+| Solução por pseudo-elementos | commit `c53177d` — `::after` face amarela, `::before` bloco verde, `isolation: isolate` |
+| 7 commits | `1a54353`, `fe6569b`, `26d9ebd`, `d028842`, `ee14559`, `c53177d`, `a1b9184` |

--- a/docs/marketing/linkedin/post-3-arquitetura.md
+++ b/docs/marketing/linkedin/post-3-arquitetura.md
@@ -1,0 +1,101 @@
+# Post 3 — Arquitetura
+
+**Tema**: trade-offs de Jamstack explicados por consequência, não por buzzword.
+**Objetivo**: mostrar raciocínio de arquitetura — inclusive o custo escondido da escolha.
+**Imagem**: carrossel de 6 slides (`slides/post-3-slides.html`).
+
+---
+
+## Texto para colar
+
+```
+Meu site é prerenderizado. Todas as páginas viram HTML estático no build.
+
+Isso significa que um grupo novo cadastrado no CMS simplesmente não existe. A página dele dá 404.
+
+Não é bug. É a consequência direta da arquitetura — e vale a pena entender por quê, porque quase todo tutorial de Jamstack para de contar a história antes dessa parte.
+
+O Nuxt roda o prerender com crawlLinks: true. Ele começa na home, segue todos os links que encontra e gera um HTML para cada rota que descobriu. É isso que deixa o site rápido: quando o usuário chega, não tem servidor renderizando nada.
+
+Mas repare no tempo verbal. Ele descobriu as rotas NO BUILD.
+
+Grupo cadastrado no Hygraph depois disso = rota que nunca foi visitada pelo crawler = arquivo que não existe no dist.
+
+A solução não está em lugar nenhum do repositório: é um webhook do Hygraph apontando para o build hook da Netlify. Publicou conteúdo, dispara build. Infraestrutura invisível no código e requisito absoluto de funcionamento.
+
+Achei isso importante o suficiente para virar documentação, porque é exatamente o tipo de coisa que some quando alguém assume o projeto.
+
+Outras decisões da mesma arquitetura:
+
+→ Leitura pública vai direto do browser para o Hygraph. Escrita, nunca. Todo POST passa por uma server route, porque o token de escrita não pode existir no bundle do client. A regra está escrita como comentário no composable, para ninguém "otimizar" isso depois.
+
+→ O endpoint de um grupo responde com max-age=60, s-maxage=300, stale-while-revalidate=600. O formulário de correção não precisa de dado fresquíssimo, e cada cache miss custa uma chamada autenticada ao CMS.
+
+→ As páginas de formulário são casca estática prerenderizada + fetch só no client. O HTML é sempre o mesmo; o dado do grupo chega depois.
+
+E duas armadilhas de Leaflet com SSR, que custaram tempo:
+
+1. Importar o Leaflet como valor quebra o SSR — ele toca em window na avaliação do módulo. No escopo do módulo só entram tipos; o import real é tardio, dentro do componente .client.
+
+2. Os estilos do pin não podem ser scoped. O Leaflet renderiza marcadores fora da árvore do componente, então o atributo de escopo do Vue nunca chega neles.
+
+O mapa, aliás, é Leaflet com tiles do CARTO. Sem API key, sem cota, sem cartão de crédito.
+
+Se eu tivesse que mudar uma coisa hoje: trocar o rebuild inteiro por ISR via routeRules. Publicar um grupo não deveria custar um build do site todo.
+
+🔗 https://pedalasampa.netlify.app
+🔗 https://github.com/adams-alves-dev/pedala-sampa
+
+#nuxt #jamstack #arquitetura #frontend #webdev
+```
+
+---
+
+## Variante curta (~700 caracteres)
+
+```
+Meu site é prerenderizado. Um grupo novo no CMS dá 404.
+
+Não é bug — é a consequência da arquitetura.
+
+O Nuxt roda prerender com crawlLinks: começa na home, segue os links e gera um HTML por rota descoberta. Repare no tempo verbal: descobriu NO BUILD.
+
+Conteúdo publicado depois = rota que o crawler nunca visitou = arquivo que não existe.
+
+A solução não está no repositório: webhook do CMS → build hook da Netlify. Publicou, dispara build.
+
+Infraestrutura invisível no código e requisito absoluto de funcionamento. É o tipo de coisa que some quando alguém assume o projeto — por isso virou documentação.
+
+#nuxt #jamstack #webdev
+```
+
+---
+
+## Carrossel — 6 slides
+
+| # | Conteúdo |
+|---|---|
+| 1 | **Capa** — "Prerender é rápido. Também é uma foto congelada." |
+| 2 | **Os dois caminhos do dado** — browser → CMS (leitura) / browser → server route → CMS (escrita), com o motivo: o token |
+| 3 | **O problema** — linha do tempo: build → grupo publicado → 404 |
+| 4 | **A solução** — webhook Hygraph → build hook Netlify (e o aviso: mora fora do repo) |
+| 5 | **Cache** — o header `Cache-Control` com o comentário real do código |
+| 6 | **Leaflet × SSR** — as duas armadilhas + fecho com links |
+
+---
+
+## Fontes
+
+| Afirmação | Onde se verifica |
+|---|---|
+| Prerender com `crawlLinks` | `nuxt.config.ts:57-63` — `nitro: { preset: 'netlify', prerender: { crawlLinks: true, routes: ['/'] } }` |
+| Server routes viram Netlify Functions | `nuxt.config.ts:55-56` (comentário) e `netlify.toml` |
+| Webhook Hygraph → build hook | Configuração externa ao repositório (Hygraph + Netlify). **Não há arquivo que prove isso** — é a peça de infra fora do código |
+| Leitura direto do client | `composables/useHygraph.ts` (endpoint público) |
+| Escrita só via server route | `composables/useSuggestions.ts` e `useFeedback.ts` (comentário explícito) |
+| Cache do endpoint de grupo | `server/api/groups/[slug].get.ts:78-84` — *"o form de correção não precisa de dado fresquíssimo e cada miss custa uma chamada autenticada ao Hygraph"* |
+| Casca estática + fetch no client | `components/contribution/SuggestionUpdateForm.vue:94` — `useAsyncData(..., { server: false })` |
+| Leaflet como valor quebra o SSR | `components/contribution/LocationPicker.client.vue:40` — *"só tipos no escopo do módulo: importar o leaflet como valor quebra o SSR"* |
+| Estilos do pin não podem ser scoped | `components/map/GroupMap.client.vue:205` — *"Leaflet renders markers/containers outside the scoped tree, so these are global"* |
+| Tiles CARTO sem API key | `components/map/MapTileLayer.vue` — `basemaps.cartocdn.com`, atribuição OSM + CARTO |
+| ISR como evolução | Avaliação própria, apresentada no post como opinião ("se eu tivesse que mudar") — não é decisão tomada |

--- a/docs/marketing/linkedin/post-4-comunidade.md
+++ b/docs/marketing/linkedin/post-4-comunidade.md
@@ -1,0 +1,113 @@
+# Post 4 — Comunidade & segurança
+
+**Tema**: aceitar contribuição anônima na internet aberta sem virar alvo de spam.
+**Objetivo**: mostrar maturidade — defesa em camadas, honestidade sobre os limites da própria defesa, e LGPD tratada como requisito.
+**Imagem**: carrossel de 7 slides (`slides/post-4-slides.html`).
+
+---
+
+## Texto para colar
+
+```
+Qualquer pessoa pode cadastrar um grupo no meu site. Sem login, sem conta, sem e-mail de confirmação.
+
+Isso é, literalmente, um formulário aberto na internet. É um convite para spam — a menos que você planeje para isso.
+
+Fiz a conta ao contrário: pedir cadastro mataria a contribuição. Quem tem a informação certa é quem organiza o pedal, e essa pessoa não vai criar uma conta num site que ela nunca viu para consertar o horário de saída dela. Ou é fácil, ou não acontece.
+
+Então a fricção saiu do usuário e foi para as camadas de trás.
+
+CAMADA 1 — Honeypot
+Um campo escondido no formulário. Humano não vê, bot preenche. Se vier preenchido, a API responde 200 e não cria nada. O bot registra sucesso e vai embora feliz. Custa 3 linhas e derruba a maior parte do tráfego automatizado burro.
+
+CAMADA 2 — Rate limit por IP
+5 requisições por janela de 10 minutos.
+
+CAMADA 3 — Cloudflare Turnstile
+Atrás de feature flag, para poder ligar e desligar sem deploy.
+
+CAMADA 4 — Zod em toda entrada
+Tipo, formato, tamanho, e sanitização de HTML.
+
+Aqui tem um detalhe de ordem que é fácil errar: a validação do Zod roda ANTES da verificação do Turnstile.
+
+O token do Turnstile é de uso único. Se você checa o desafio primeiro e só depois descobre que faltou um campo obrigatório, você queimou o token — e o reenvio corrigido do usuário falha, mesmo estando certo. A pessoa preenche tudo de novo e leva erro de novo.
+
+Ordem errada não quebra o teste. Quebra o usuário honesto.
+
+E sobre a camada 2, uma confissão que está escrita no próprio código: em serverless, cada instância tem a própria memória e as instâncias são recicladas. Então o rate limit vale por instância. É uma barreira contra rajada, não uma garantia global.
+
+Deixei isso como comentário no arquivo, junto com a evolução sugerida (Redis compartilhado). Defesa que você não sabe onde falha não é defesa — é sorte.
+
+A curadoria segue o mesmo princípio. A CLI que transforma sugestão aprovada em conteúdo real usa um token separado do público. E esse token NÃO tem permissão de publish. De propósito.
+
+O resultado é que nenhuma automação minha consegue colocar conteúdo no ar. O máximo que ela faz é criar rascunho. Publicar é um humano, no CMS. Quando a única forma de ir ao ar é alguém clicando, o pior caso de um bug na automação é rascunho sujo — nunca conteúdo errado em produção.
+
+Ainda: o aviso que chega no Discord a cada sugestão vai com allowed_mentions vazio. Texto livre de desconhecido não vai pingar @everyone no meu servidor. E o envio tem timeout de 3 segundos e é best-effort: se o Discord cair, a sugestão do usuário é salva do mesmo jeito. A notificação é minha conveniência, não parte do contrato com quem contribuiu.
+
+Por fim, LGPD. O formulário coleta e-mail, e esse e-mail viaja no aviso do Discord. Isso está documentado e a instrução é explícita: canal privado. Além das páginas de privacidade e termos no ar, dizendo o que é coletado e por quê.
+
+Dado de terceiro é responsabilidade, não feature.
+
+🔗 https://pedalasampa.netlify.app
+🔗 https://github.com/adams-alves-dev/pedala-sampa
+
+#seguranca #backend #webdev #lgpd #nuxt
+```
+
+---
+
+## Variante curta (~800 caracteres)
+
+```
+Qualquer pessoa pode cadastrar um grupo no meu site. Sem login, sem conta.
+
+É um formulário aberto na internet — convite para spam, a menos que você planeje.
+
+4 camadas: honeypot (bot preenche campo invisível, API responde 200 e não cria nada), rate limit por IP, Turnstile atrás de feature flag, e Zod em tudo.
+
+O detalhe fácil de errar: o Zod roda ANTES do Turnstile.
+
+O token do Turnstile é de uso único. Se você checa o desafio primeiro e depois descobre que faltou um campo, você queimou o token — e o reenvio corrigido do usuário falha, mesmo estando certo.
+
+Ordem errada não quebra o teste. Quebra o usuário honesto.
+
+#seguranca #backend #webdev
+```
+
+---
+
+## Carrossel — 7 slides
+
+| # | Conteúdo |
+|---|---|
+| 1 | **Capa** — "Formulário aberto na internet. 4 camadas para não virar alvo." |
+| 2 | **A decisão** — pedir cadastro mataria a contribuição; a fricção sai do usuário e vai para trás |
+| 3 | **Honeypot** — o campo invisível e o 200 mentiroso (com o snippet) |
+| 4 | **A ordem que importa** — Zod antes do Turnstile, e por quê (token de uso único) |
+| 5 | **A confissão honesta** — o comentário real do `rate-limit.ts` |
+| 6 | **Curadoria** — dois tokens, zero permissão de publish, humano no fim |
+| 7 | **Discord + LGPD** — `allowed_mentions: []`, timeout 3s, canal privado + links |
+
+---
+
+## Fontes
+
+| Afirmação | Onde se verifica |
+|---|---|
+| Honeypot com 200 silencioso | `server/api/suggestions.post.ts:15-18` — *"bots preenchem o campo escondido; respondemos 200 sem criar nada"* |
+| Rate limit 5 req / 10 min | `server/utils/rate-limit.ts:10-11` — `WINDOW_MS = 10 * 60 * 1000`, `MAX_REQUESTS_PER_WINDOW = 5` |
+| Confissão sobre serverless | `server/utils/rate-limit.ts:1-9` — *"cada instância tem sua própria memória… é uma barreira contra rajadas, não uma garantia global. Evolução sugerida: Upstash Redis"* |
+| Turnstile atrás de flag | `server/utils/turnstile.ts`, env `TURNSTILE_ENABLED` |
+| Zod antes do Turnstile | `server/api/suggestions.post.ts:31-35` — *"valida ANTES do Turnstile: o token do desafio é de uso único, e um 400 de validação não pode consumi-lo — senão o reenvio corrigido falharia"* |
+| Dois tokens, sem publish | `docs/curation.md` — `GRAPHQL_TOKEN` público read-only vs `HYGRAPH_CURATION_TOKEN`; PAT sem Publish/Unpublish/Delete de propósito |
+| Curadoria cria só draft | `docs/curation.md`; `scripts/curate-runner.ts` |
+| `allowed_mentions: { parse: [] }` | `lib/discord.ts:1-9` — *"neutraliza pings (@everyone/@here/usuários) que possam vir do texto livre do usuário"* |
+| Timeout 3s, best-effort | `server/utils/notify.ts:7-24` — `DISCORD_TIMEOUT_MS = 3000`; *"nunca lança (uma falha no aviso não derruba o cadastro)"* |
+| LGPD / canal privado | `docs/curation.md`, seção 3 |
+| Páginas de privacidade e termos | `pages/privacy.vue`, `pages/terms.vue` |
+
+⚠️ **Nota de honestidade**: o post afirma que o honeypot "derruba a maior parte do tráfego
+automatizado burro" — isso é conhecimento geral da técnica, não uma métrica medida neste projeto.
+Não há telemetria de bots bloqueados. Se quiser evitar qualquer leitura de métrica, troque por
+"custa 3 linhas e resolve o bot mais simples".

--- a/docs/marketing/linkedin/post-5-processo.md
+++ b/docs/marketing/linkedin/post-5-processo.md
@@ -1,0 +1,120 @@
+# Post 5 — Processo & entrega (fechamento da série)
+
+**Tema**: velocidade sustentável vem de automação, não de heroísmo.
+**Objetivo**: fechar a série. É o post que mais fala com quem contrata — mostra disciplina de entrega.
+**Imagem**: carrossel de 7 slides (`slides/post-5-slides.html`).
+
+---
+
+## Texto para colar
+
+```
+Este projeto ficou 4 anos e 8 meses parado.
+
+Último commit da versão antiga: setembro de 2021. Um app Nuxt 2 que funcionava e que eu abandonei.
+
+Quando voltei, em junho de 2026, saíram 5 versões em 8 dias.
+
+A diferença não foi disposição. Foi tooling.
+
+A retomada foi um único PR que trocou Nuxt 2 por Nuxt 3 + Vue 3 + TypeScript strict, com o redesign inteiro junto. Dois dias depois, v1.0.0 no ar. Na semana seguinte: sugestões da comunidade, ritmo derivado da duração do pedal, CLI de curadoria, avisos no Discord, múltiplas agendas por grupo, canal de feedback, e as páginas de privacidade e termos.
+
+v1.0.0 em 11/06. v1.4.0 em 18/06.
+
+O que tornou esse ritmo possível não foi trabalhar mais horas. Foi não gastar decisão com o que pode ser automático.
+
+TESTES BARATOS POR DESENHO
+170 casos de teste em 19 arquivos. Isso só é sustentável porque a regra de negócio não mora em componente Vue — mora em 21 módulos puros: filtros, normalizadores, schemas, formatação de tempo.
+
+Testar função pura é escrever entrada e esperar saída. Sem montar componente, sem mockar CMS, sem esperar renderização. O componente fica com o que é dele: apresentar.
+
+Quando testar dói, quase sempre o problema é onde a lógica está — não a ferramenta de teste.
+
+O ERRO PEGO ANTES DO CI
+Três hooks de git: lint-staged no pre-commit, commitlint no commit-msg, typecheck no pre-push.
+
+CI vermelho é feedback caro. Chega minutos depois, quando você já está em outra coisa, e custa um push a mais para consertar. O mesmo erro pego no commit custa 4 segundos.
+
+RELEASE EM UMA DECISÃO HUMANA
+Conventional Commits alimentam o release-please, que abre a PR de release com CHANGELOG e a versão SemVer já calculada. Eu não escrevo changelog. Eu não escolho número de versão. Eu aprovo ou não aprovo.
+
+Uma pegadinha que custou tempo aqui: o GITHUB_TOKEN padrão do Actions não dispara o workflow que cria a tag. Ação feita por token do sistema não gera evento para o próprio sistema — proteção contra loop infinito. Precisa de um PAT.
+
+E depois do release, back-merge automático de main para develop, para as branches não divergirem sozinhas.
+
+MANUTENÇÃO É TRABALHO, NÃO INTERRUPÇÃO
+Num único dia de julho entraram 7 atualizações de dependência via Dependabot, incluindo duas CVEs. Sem drama, porque o pipeline diz em 3 minutos se alguma quebrou alguma coisa.
+
+Onde eu fui deliberadamente chato: código, rotas, arquivos e identificadores em inglês. Interface e documentação em português. A fronteira é explícita, então ninguém precisa decidir caso a caso.
+
+O ponto que eu queria deixar, fechando esta série:
+
+O tooling não é o que você monta quando o projeto fica grande. É o que permite um projeto pequeno voltar do zero depois de 4 anos e entregar 5 versões numa semana — com testes, changelog e versionamento, sem nenhum deles custando atenção.
+
+Ferramenta boa não é a que faz você ir rápido. É a que faz o certo ser o caminho mais fácil.
+
+🔗 O site: https://pedalasampa.netlify.app
+🔗 O código: https://github.com/adams-alves-dev/pedala-sampa
+
+Se você pedala em São Paulo e conhece um grupo que não está no mapa, é literalmente um formulário. Sem cadastro.
+
+#devops #cicd #testes #frontend #opensource
+```
+
+---
+
+## Variante curta (~700 caracteres)
+
+```
+Este projeto ficou 4 anos e 8 meses parado.
+
+Quando voltei, saíram 5 versões em 8 dias. A diferença não foi disposição — foi tooling.
+
+170 testes que são baratos porque a regra de negócio não mora em componente: mora em 21 módulos puros. Testar função pura é entrada e saída, sem montar componente nem mockar CMS.
+
+Três hooks de git, porque CI vermelho é feedback caro: chega minutos depois, quando você já está em outra coisa. O mesmo erro pego no commit custa 4 segundos.
+
+E release-please: eu não escrevo changelog nem escolho versão. Aprovo ou não aprovo.
+
+Ferramenta boa não é a que faz você ir rápido. É a que faz o certo ser o caminho mais fácil.
+
+#devops #cicd #testes
+```
+
+---
+
+## Carrossel — 7 slides
+
+| # | Conteúdo |
+|---|---|
+| 1 | **Capa** — linha do tempo 2021 ▸▸▸▸ 2026, com o gap de 4 anos como elemento visual |
+| 2 | **5 releases em 8 dias** — tabela v1.0.0 → v1.4.0 com o que cada uma entregou |
+| 3 | **Os números** — 165 commits, 170 testes, 10 rotas, 26 componentes, 21 módulos puros |
+| 4 | **Por que os testes foram baratos** — lógica em `lib/`, componente só apresenta |
+| 5 | **O pipeline** — commit → husky → CI → release-please → deploy |
+| 6 | **A pegadinha do PAT** — por que o `GITHUB_TOKEN` não dispara o workflow |
+| 7 | **Fecho** — "ferramenta boa faz o certo ser o caminho mais fácil" + links |
+
+---
+
+## Fontes
+
+| Afirmação | Onde se verifica |
+|---|---|
+| Primeiro commit em 03/03/2021 | `git log --reverse --date=short` |
+| Último commit da era antiga: 30/09/2021 | `1cdf72a` — merge do PR #55 |
+| Retomada em 09/06/2026 | `a31d54c` — *"feat: migração Nuxt 3 + redesign wayfinding"* (PR #69) |
+| Gap de 4 anos e 8 meses | 30/09/2021 → 09/06/2026 |
+| 5 releases em 8 dias | tags: v1.0.0 `2026-06-11`, v1.1.0 e v1.2.0 `2026-06-15`, v1.3.0 e v1.4.0 `2026-06-18` |
+| 165 commits | `git rev-list --count HEAD` |
+| 170 testes em 19 arquivos | `tests/unit/` — contagem de `it(`/`test(` |
+| 10 rotas, 26 componentes, 21 módulos, 7 composables | contagem em `pages/`, `components/`, `lib/`, `composables/` |
+| 3 hooks de git | `.husky/` — `pre-commit` (lint-staged), `commit-msg` (commitlint), `pre-push` |
+| CI: lint → typecheck → test | `.github/workflows/ci.yml` |
+| release-please + PAT | `.github/workflows/release-please.yml`; `CONTRIBUTING.md` — *"o `GITHUB_TOKEN` não dispara o run que cria a tag/release"*; commit `7935d95` *"release em 1 decisão humana"* |
+| Back-merge main → develop | `40256f6` e `release-please.yml` |
+| 7 bumps do Dependabot num dia | commits de 2026-07-28, PRs #106–#112; `39f5d88` cita CVE-2026-13149 e CVE-2026-14257 |
+| Identificadores em inglês | `78e28aa` — *"renomear identificadores, rotas e arquivos para inglês"*; regra em `AGENTS.md` / `CONTRIBUTING.md` |
+
+⚠️ **Conferir antes de publicar**: `165 commits` é a contagem em `HEAD` no dia 29/07/2026 —
+vai crescer. Rode `git rev-list --count HEAD` antes de postar, ou remova o número.

--- a/docs/marketing/linkedin/post-5-processo.md
+++ b/docs/marketing/linkedin/post-5-processo.md
@@ -1,6 +1,6 @@
 # Post 5 — Processo & entrega (fechamento da série)
 
-**Tema**: velocidade sustentável vem de automação, não de heroísmo.
+**Tema**: o tooling que sustenta entrega rápida sem abrir mão de qualidade, num projeto solo.
 **Objetivo**: fechar a série. É o post que mais fala com quem contrata — mostra disciplina de entrega.
 **Imagem**: carrossel de 7 slides (`slides/post-5-slides.html`).
 
@@ -9,22 +9,22 @@
 ## Texto para colar
 
 ```
-Este projeto ficou 4 anos e 8 meses parado.
+Entreguei 5 versões do meu projeto em 8 dias.
 
-Último commit da versão antiga: setembro de 2021. Um app Nuxt 2 que funcionava e que eu abandonei.
+Não escrevi um changelog sequer. E não escolhi nenhum número de versão.
 
-Quando voltei, em junho de 2026, saíram 5 versões em 8 dias.
+Isso não é preguiça — é exatamente o ponto.
 
-A diferença não foi disposição. Foi tooling.
+Num projeto pessoal, sozinho, a coisa mais fácil do mundo é pular processo. Sem teste, sem changelog, sem versionamento, commit direto na main. Não tem ninguém cobrando.
 
-A retomada foi um único PR que trocou Nuxt 2 por Nuxt 3 + Vue 3 + TypeScript strict, com o redesign inteiro junto. Dois dias depois, v1.0.0 no ar. Na semana seguinte: sugestões da comunidade, ritmo derivado da duração do pedal, CLI de curadoria, avisos no Discord, múltiplas agendas por grupo, canal de feedback, e as páginas de privacidade e termos.
+Só que "não tem ninguém cobrando" também significa "não tem ninguém para lembrar o que mudou". Três semanas depois você não sabe mais qual mudança quebrou o quê, e a única forma de descobrir é ler diff.
 
-v1.0.0 em 11/06. v1.4.0 em 18/06.
+Então montei o tooling antes das features. E ele se pagou na primeira semana:
 
-O que tornou esse ritmo possível não foi trabalhar mais horas. Foi não gastar decisão com o que pode ser automático.
+v1.0.0 em 11/06. v1.4.0 em 18/06. No meio: sugestões da comunidade, ritmo derivado da duração do pedal, CLI de curadoria, avisos no Discord, múltiplas agendas por grupo, canal de feedback, páginas de privacidade e termos.
 
 TESTES BARATOS POR DESENHO
-170 casos de teste em 19 arquivos. Isso só é sustentável porque a regra de negócio não mora em componente Vue — mora em 21 módulos puros: filtros, normalizadores, schemas, formatação de tempo.
+170 casos de teste, em 19 arquivos. Isso só é sustentável porque a regra de negócio não mora em componente Vue — mora em 21 módulos puros: filtros, normalizadores, schemas, formatação de tempo.
 
 Testar função pura é escrever entrada e esperar saída. Sem montar componente, sem mockar CMS, sem esperar renderização. O componente fica com o que é dele: apresentar.
 
@@ -36,20 +36,20 @@ Três hooks de git: lint-staged no pre-commit, commitlint no commit-msg, typeche
 CI vermelho é feedback caro. Chega minutos depois, quando você já está em outra coisa, e custa um push a mais para consertar. O mesmo erro pego no commit custa 4 segundos.
 
 RELEASE EM UMA DECISÃO HUMANA
-Conventional Commits alimentam o release-please, que abre a PR de release com CHANGELOG e a versão SemVer já calculada. Eu não escrevo changelog. Eu não escolho número de versão. Eu aprovo ou não aprovo.
+Conventional Commits alimentam o release-please, que abre a PR de release com o CHANGELOG escrito e a versão SemVer já calculada. Eu aprovo ou não aprovo. É a única decisão que sobra para mim.
 
-Uma pegadinha que custou tempo aqui: o GITHUB_TOKEN padrão do Actions não dispara o workflow que cria a tag. Ação feita por token do sistema não gera evento para o próprio sistema — proteção contra loop infinito. Precisa de um PAT.
+Uma pegadinha que custou tempo aqui: o GITHUB_TOKEN padrão do Actions não dispara o workflow que cria a tag. Ação feita com o token do sistema não gera evento para o próprio sistema — é proteção contra loop infinito. A saída é um PAT.
 
 E depois do release, back-merge automático de main para develop, para as branches não divergirem sozinhas.
 
 MANUTENÇÃO É TRABALHO, NÃO INTERRUPÇÃO
-Num único dia de julho entraram 7 atualizações de dependência via Dependabot, incluindo duas CVEs. Sem drama, porque o pipeline diz em 3 minutos se alguma quebrou alguma coisa.
+Num único dia entraram 7 atualizações de dependência via Dependabot, incluindo duas CVEs. Sem drama, porque o pipeline diz em 3 minutos se alguma quebrou alguma coisa.
 
-Onde eu fui deliberadamente chato: código, rotas, arquivos e identificadores em inglês. Interface e documentação em português. A fronteira é explícita, então ninguém precisa decidir caso a caso.
+Onde eu fui deliberadamente chato: código, rotas, arquivos e identificadores em inglês. Interface e documentação em português. A fronteira é explícita, então ninguém precisa decidir caso a caso — nem eu, três meses depois.
 
 O ponto que eu queria deixar, fechando esta série:
 
-O tooling não é o que você monta quando o projeto fica grande. É o que permite um projeto pequeno voltar do zero depois de 4 anos e entregar 5 versões numa semana — com testes, changelog e versionamento, sem nenhum deles custando atenção.
+Tooling não é o que você monta quando o projeto fica grande. É o que faz um projeto pequeno entregar cinco versões numa semana com testes, changelog e versionamento — sem que nenhum dos três custe atenção.
 
 Ferramenta boa não é a que faz você ir rápido. É a que faz o certo ser o caminho mais fácil.
 
@@ -66,15 +66,13 @@ Se você pedala em São Paulo e conhece um grupo que não está no mapa, é lite
 ## Variante curta (~700 caracteres)
 
 ```
-Este projeto ficou 4 anos e 8 meses parado.
+Entreguei 5 versões do meu projeto em 8 dias. Não escrevi um changelog sequer.
 
-Quando voltei, saíram 5 versões em 8 dias. A diferença não foi disposição — foi tooling.
+Num projeto solo, a coisa mais fácil é pular processo — não tem ninguém cobrando. Só que também não tem ninguém para lembrar o que mudou.
 
 170 testes que são baratos porque a regra de negócio não mora em componente: mora em 21 módulos puros. Testar função pura é entrada e saída, sem montar componente nem mockar CMS.
 
 Três hooks de git, porque CI vermelho é feedback caro: chega minutos depois, quando você já está em outra coisa. O mesmo erro pego no commit custa 4 segundos.
-
-E release-please: eu não escrevo changelog nem escolho versão. Aprovo ou não aprovo.
 
 Ferramenta boa não é a que faz você ir rápido. É a que faz o certo ser o caminho mais fácil.
 
@@ -87,9 +85,9 @@ Ferramenta boa não é a que faz você ir rápido. É a que faz o certo ser o ca
 
 | # | Conteúdo |
 |---|---|
-| 1 | **Capa** — linha do tempo 2021 ▸▸▸▸ 2026, com o gap de 4 anos como elemento visual |
-| 2 | **5 releases em 8 dias** — tabela v1.0.0 → v1.4.0 com o que cada uma entregou |
-| 3 | **Os números** — 165 commits, 170 testes, 10 rotas, 26 componentes, 21 módulos puros |
+| 1 | **Capa** — "5 versões em 8 dias. Nenhum changelog escrito à mão." |
+| 2 | **As 5 releases** — tabela v1.0.0 → v1.4.0 com o que cada uma entregou |
+| 3 | **Os números** — 170 testes, 21 módulos puros, 26 componentes, 10 rotas |
 | 4 | **Por que os testes foram baratos** — lógica em `lib/`, componente só apresenta |
 | 5 | **O pipeline** — commit → husky → CI → release-please → deploy |
 | 6 | **A pegadinha do PAT** — por que o `GITHUB_TOKEN` não dispara o workflow |
@@ -101,14 +99,10 @@ Ferramenta boa não é a que faz você ir rápido. É a que faz o certo ser o ca
 
 | Afirmação | Onde se verifica |
 |---|---|
-| Primeiro commit em 03/03/2021 | `git log --reverse --date=short` |
-| Último commit da era antiga: 30/09/2021 | `1cdf72a` — merge do PR #55 |
-| Retomada em 09/06/2026 | `a31d54c` — *"feat: migração Nuxt 3 + redesign wayfinding"* (PR #69) |
-| Gap de 4 anos e 8 meses | 30/09/2021 → 09/06/2026 |
 | 5 releases em 8 dias | tags: v1.0.0 `2026-06-11`, v1.1.0 e v1.2.0 `2026-06-15`, v1.3.0 e v1.4.0 `2026-06-18` |
-| 165 commits | `git rev-list --count HEAD` |
+| O que cada release entregou | `CHANGELOG.md` |
 | 170 testes em 19 arquivos | `tests/unit/` — contagem de `it(`/`test(` |
-| 10 rotas, 26 componentes, 21 módulos, 7 composables | contagem em `pages/`, `components/`, `lib/`, `composables/` |
+| 21 módulos puros, 26 componentes, 10 rotas, 7 composables | contagem em `lib/`, `components/`, `pages/`, `composables/` |
 | 3 hooks de git | `.husky/` — `pre-commit` (lint-staged), `commit-msg` (commitlint), `pre-push` |
 | CI: lint → typecheck → test | `.github/workflows/ci.yml` |
 | release-please + PAT | `.github/workflows/release-please.yml`; `CONTRIBUTING.md` — *"o `GITHUB_TOKEN` não dispara o run que cria a tag/release"*; commit `7935d95` *"release em 1 decisão humana"* |
@@ -116,5 +110,9 @@ Ferramenta boa não é a que faz você ir rápido. É a que faz o certo ser o ca
 | 7 bumps do Dependabot num dia | commits de 2026-07-28, PRs #106–#112; `39f5d88` cita CVE-2026-13149 e CVE-2026-14257 |
 | Identificadores em inglês | `78e28aa` — *"renomear identificadores, rotas e arquivos para inglês"*; regra em `AGENTS.md` / `CONTRIBUTING.md` |
 
-⚠️ **Conferir antes de publicar**: `165 commits` é a contagem em `HEAD` no dia 29/07/2026 —
-vai crescer. Rode `git rev-list --count HEAD` antes de postar, ou remova o número.
+⚠️ **Conferir antes de publicar**: as contagens (testes, módulos, componentes) mudam conforme o
+projeto anda. Recontar, ou tirar o número, antes de postar.
+
+📌 **Enquadramento**: este post fala do processo da entrega, não da história do repositório. O
+período em que o projeto ficou sem commits foi deliberadamente deixado de fora — se for reescrever,
+manter esse recorte.

--- a/docs/marketing/linkedin/slides/_base.css
+++ b/docs/marketing/linkedin/slides/_base.css
@@ -1,0 +1,600 @@
+/*
+ * Base dos slides de carrossel para LinkedIn — 1080×1350 (4:5).
+ *
+ * Os tokens vêm do design system do próprio projeto
+ * (docs/redesign/design_handoff_pedala_sampa/design-system/), tema Ciclovia,
+ * para os slides parecerem parte da marca e não um template genérico.
+ *
+ * Regras herdadas do sistema, respeitadas aqui:
+ *   - nenhuma cor fora dos tokens (variações derivadas, não hex novo)
+ *   - sombra dura deslocada, blur zero
+ *   - CTA / destaque em paralelogramo via clip-path
+ *   - card com trilho verde de 5px
+ *   - sem gradiente, sem card pill, sem emoji como elemento de UI
+ *
+ * Uso: abrir o HTML com ?slide=N para exibir só o slide N (facilita a captura).
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Archivo:wght@600;700;800&family=Hanken+Grotesk:wght@400;500;600;700&display=swap');
+
+:root {
+  /* tema Ciclovia — themes.css */
+  --asphalt: #11271c;
+  --concrete: #dce7da;
+  --paper: #f4f9f0;
+  --green: #1f8a4c;
+  --green-dark: #136636;
+  --green-tint: #d7ebd6;
+  --yellow: #f2b33a;
+  --yellow-tint: #f8eac4;
+  --red: #d8432f;
+  --blue: #1e7a9e;
+  --border: #bbcdb6;
+  --paper-2: #eaf2e4;
+  --concrete-dk: #ccd9c7;
+
+  --asphalt-80: rgb(17 39 28 / 80%);
+  --asphalt-58: rgb(17 39 28 / 58%);
+  --asphalt-46: rgb(17 39 28 / 46%);
+
+  --font-display: 'Archivo', ui-sans-serif, system-ui, sans-serif;
+  --font-body: 'Hanken Grotesk', ui-sans-serif, system-ui, sans-serif;
+
+  --shadow-hard: 8px 8px 0 var(--asphalt);
+  --shadow-hard-green: 8px 8px 0 var(--green-dark);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: #55605a;
+  font-family: var(--font-body);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+  padding: 40px 0;
+}
+
+/* ---------------------------------------------------------------- slide */
+
+.slide {
+  width: 1080px;
+  height: 1350px;
+  flex: none;
+  background: var(--concrete);
+  color: var(--asphalt);
+  padding: 88px 80px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.slide--dark {
+  background: var(--asphalt);
+  color: var(--concrete);
+}
+
+.slide--paper {
+  background: var(--paper);
+}
+
+/* numeração do slide, canto inferior direito */
+.slide::after {
+  content: attr(data-n);
+  position: absolute;
+  right: 56px;
+  bottom: 48px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 26px;
+  color: var(--asphalt-46);
+  font-variant-numeric: tabular-nums;
+}
+
+.slide--dark::after {
+  color: rgb(220 231 218 / 46%);
+}
+
+/* ------------------------------------------------------------ tipografia */
+
+.eyebrow {
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--green);
+  margin-bottom: 28px;
+}
+
+.slide--dark .eyebrow {
+  color: var(--yellow);
+}
+
+h1 {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 96px;
+  line-height: 0.98;
+  letter-spacing: -0.03em;
+}
+
+h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 62px;
+  line-height: 1.04;
+  letter-spacing: -0.02em;
+  margin-bottom: 40px;
+}
+
+h3 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 38px;
+  line-height: 1.12;
+  letter-spacing: -0.01em;
+}
+
+p {
+  font-size: 34px;
+  line-height: 1.42;
+  color: var(--asphalt-80);
+}
+
+.slide--dark p {
+  color: rgb(220 231 218 / 82%);
+}
+
+p + p {
+  margin-top: 28px;
+}
+
+.lead {
+  font-size: 40px;
+  line-height: 1.34;
+}
+
+strong {
+  font-weight: 700;
+  color: var(--asphalt);
+}
+
+.slide--dark strong {
+  color: var(--concrete);
+}
+
+.hl-green {
+  color: var(--green);
+  font-weight: 700;
+}
+.hl-yellow {
+  color: var(--yellow);
+  font-weight: 700;
+}
+.hl-red {
+  color: var(--red);
+  font-weight: 700;
+}
+
+.slide--dark .hl-green {
+  color: #4ec27d;
+}
+
+/* ---------------------------------------------------------------- layout */
+
+.spacer {
+  flex: 1;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+}
+
+/* tom mínimo aqui é --asphalt-58: em --asphalt-46 o contraste cai para 2,7:1,
+   abaixo do 3:1 exigido para texto grande — e isto é lido no celular */
+.footer-note {
+  font-size: 26px;
+  color: var(--asphalt-58);
+  letter-spacing: 0.02em;
+}
+
+.slide--dark .footer-note {
+  color: rgb(220 231 218 / 68%);
+}
+
+/* --------------------------------------------------------------- marca */
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 30px;
+}
+
+.brand__pin {
+  width: 44px;
+  height: 44px;
+  background: var(--yellow);
+  border: 3px solid var(--asphalt);
+  border-radius: 50% 50% 50% 4px;
+  transform: rotate(-45deg);
+}
+
+.slide--dark .brand__pin {
+  border-color: var(--concrete);
+}
+
+/* ---------------------------------------------------------------- cards */
+
+/* card com trilho verde de 5px — signature move do design system */
+.card {
+  background: var(--paper);
+  border: 3px solid var(--asphalt);
+  border-left-width: 12px;
+  border-left-color: var(--green);
+  padding: 34px 38px;
+  box-shadow: var(--shadow-hard);
+}
+
+.card h3 {
+  margin-bottom: 12px;
+}
+
+.card p {
+  font-size: 30px;
+}
+
+.slide--dark .card {
+  background: rgb(220 231 218 / 8%);
+  border-color: var(--concrete);
+  border-left-color: var(--green);
+  box-shadow: 8px 8px 0 rgb(220 231 218 / 22%);
+}
+
+.slide--dark .card h3,
+.slide--dark .card p {
+  color: var(--concrete);
+}
+
+/* --------------------------------------------------------------- swatch */
+
+.swatches {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 22px;
+}
+
+.swatch {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  border: 3px solid var(--asphalt);
+  background: var(--paper);
+  padding: 18px 22px;
+}
+
+.swatch__chip {
+  width: 72px;
+  height: 72px;
+  flex: none;
+  border: 3px solid var(--asphalt);
+}
+
+.swatch__name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 27px;
+  line-height: 1.2;
+}
+
+.swatch__hex {
+  font-size: 24px;
+  color: var(--asphalt-58);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+
+/* ------------------------------------------------------------------ CTA */
+
+/* paralelogramo via clip-path — o elemento que gerou o bug do post 2 */
+.cta {
+  display: inline-block;
+  /* o slide é flex column: sem isto o botão estica na largura toda */
+  align-self: flex-start;
+  background: var(--yellow);
+  color: var(--asphalt);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 32px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 26px 56px;
+  clip-path: polygon(16px 0, 100% 0, calc(100% - 16px) 100%, 0 100%);
+}
+
+/* ----------------------------------------------------------------- code */
+
+.code {
+  font-family: 'SF Mono', 'JetBrains Mono', ui-monospace, monospace;
+  background: var(--asphalt);
+  color: var(--concrete);
+  padding: 32px 36px;
+  font-size: 26px;
+  line-height: 1.6;
+  border-left: 12px solid var(--green);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.slide--dark .code {
+  background: rgb(0 0 0 / 45%);
+  border-left-color: var(--yellow);
+}
+
+.code .c {
+  color: rgb(220 231 218 / 52%);
+}
+.code .k {
+  color: var(--yellow);
+}
+.code .g {
+  color: #4ec27d;
+}
+
+/* --------------------------------------------------------------- listas */
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.item {
+  display: flex;
+  gap: 26px;
+  align-items: flex-start;
+}
+
+.item__mark {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 34px;
+  line-height: 1.2;
+  color: var(--green);
+  flex: none;
+  min-width: 56px;
+}
+
+.slide--dark .item__mark {
+  color: var(--yellow);
+}
+
+.item__body p {
+  font-size: 31px;
+}
+
+.item__body h3 {
+  margin-bottom: 8px;
+}
+
+/* --------------------------------------------------------------- número */
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 28px;
+}
+
+.stat {
+  border: 3px solid var(--asphalt);
+  background: var(--paper);
+  padding: 30px 32px;
+  box-shadow: 6px 6px 0 var(--asphalt);
+}
+
+.slide--dark .stat {
+  background: rgb(220 231 218 / 8%);
+  border-color: var(--concrete);
+  box-shadow: 6px 6px 0 rgb(220 231 218 / 22%);
+}
+
+.stat__n {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 76px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+  color: var(--green);
+}
+
+.slide--dark .stat__n {
+  color: var(--yellow);
+}
+
+.stat__label {
+  font-size: 26px;
+  color: var(--asphalt-58);
+  margin-top: 10px;
+  letter-spacing: 0.02em;
+}
+
+.slide--dark .stat__label {
+  color: rgb(220 231 218 / 65%);
+}
+
+/* --------------------------------------------------------------- imagem */
+
+.shot {
+  border: 4px solid var(--asphalt);
+  box-shadow: var(--shadow-hard);
+  width: 100%;
+  display: block;
+}
+
+.shots {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 26px;
+}
+
+.shot-label {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+
+/* -------------------------------------------------------------- tabela */
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  border: 3px solid var(--asphalt);
+  background: var(--paper);
+  box-shadow: var(--shadow-hard);
+}
+
+.row {
+  display: flex;
+  align-items: baseline;
+  gap: 26px;
+  padding: 24px 30px;
+  border-bottom: 3px solid var(--border);
+}
+
+.row:last-child {
+  border-bottom: 0;
+}
+
+.row__v {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 34px;
+  color: var(--green);
+  flex: none;
+  min-width: 130px;
+  font-variant-numeric: tabular-nums;
+}
+
+.row__t {
+  font-size: 28px;
+  line-height: 1.32;
+  color: var(--asphalt-80);
+}
+
+/* ------------------------------------------------- faixa de comparação */
+
+.compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 26px;
+}
+
+.compare__cell {
+  border: 3px solid var(--asphalt);
+  padding: 30px 32px;
+  background: var(--paper);
+}
+
+.compare__cell--bad {
+  border-color: var(--red);
+  background: rgb(216 67 47 / 8%);
+}
+
+.compare__cell--good {
+  border-color: var(--green);
+  background: var(--green-tint);
+}
+
+.compare__tag {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 25px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+
+.compare__cell--bad .compare__tag {
+  color: var(--red);
+}
+.compare__cell--good .compare__tag {
+  color: var(--green-dark);
+}
+
+.compare__cell p {
+  font-size: 28px;
+}
+
+/*
+ * Em slide escuro, `.slide--dark p` clareia o texto — mas estas células têm
+ * fundo CLARO próprio (paper / verde), então o texto sumiria. A célula --bad é
+ * a única translúcida: essa sim acompanha o fundo do slide.
+ */
+.slide--dark .compare__cell:not(.compare__cell--bad),
+.slide--dark .compare__cell:not(.compare__cell--bad) p,
+.slide--dark .compare__cell:not(.compare__cell--bad) h3,
+.slide--dark .compare__cell:not(.compare__cell--bad) strong {
+  color: var(--asphalt);
+}
+
+/* -------------------------------------------------------------- fluxo */
+
+.flow {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.flow__step {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  border: 3px solid var(--asphalt);
+  background: var(--paper);
+  padding: 24px 28px;
+}
+
+.flow__step--accent {
+  background: var(--yellow-tint);
+  border-color: var(--asphalt);
+}
+
+.flow__n {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 30px;
+  color: var(--paper);
+  background: var(--asphalt);
+  width: 54px;
+  height: 54px;
+  flex: none;
+  display: grid;
+  place-items: center;
+}
+
+.flow__t {
+  font-size: 29px;
+  line-height: 1.3;
+}
+
+.flow__arrow {
+  text-align: center;
+  font-size: 30px;
+  color: var(--asphalt-58);
+  line-height: 1;
+}

--- a/docs/marketing/linkedin/slides/post-2-slides.html
+++ b/docs/marketing/linkedin/slides/post-2-slides.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <title>Post 2 — Design & frontend | Slides</title>
+    <link rel="stylesheet" href="_base.css" />
+  </head>
+  <body>
+    <!-- 1 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="1">
+      <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
+      <div class="spacer"></div>
+      <p class="eyebrow">Design system</p>
+      <h1>Um design system que parece <span class="hl-yellow">placa de rua</span></h1>
+      <p class="lead" style="margin-top: 44px">
+        E o bug de CSS que me custou <strong>7 commits</strong> para acertar um estado de hover.
+      </p>
+      <div class="spacer"></div>
+      <span class="cta">Arraste →</span>
+    </section>
+
+    <!-- 2 ------------------------------------------------------------- -->
+    <section class="slide" data-n="2">
+      <p class="eyebrow">A base</p>
+      <h2>O sistema inteiro cabe em 8 cores</h2>
+      <div class="swatches">
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #1a120b"></span>
+          <span>
+            <span class="swatch__name">Asfalto</span><br />
+            <span class="swatch__hex">#1A120B</span>
+          </span>
+        </div>
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #e8e0d0"></span>
+          <span>
+            <span class="swatch__name">Concreto</span><br />
+            <span class="swatch__hex">#E8E0D0</span>
+          </span>
+        </div>
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #fff8ee"></span>
+          <span>
+            <span class="swatch__name">Papel</span><br />
+            <span class="swatch__hex">#FFF8EE</span>
+          </span>
+        </div>
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #00796b"></span>
+          <span>
+            <span class="swatch__name">Verde ciclovia</span><br />
+            <span class="swatch__hex">#00796B</span>
+          </span>
+        </div>
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #ffb300"></span>
+          <span>
+            <span class="swatch__name">Amarelo placa</span><br />
+            <span class="swatch__hex">#FFB300</span>
+          </span>
+        </div>
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #e53935"></span>
+          <span>
+            <span class="swatch__name">Vermelho alerta</span><br />
+            <span class="swatch__hex">#E53935</span>
+          </span>
+        </div>
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #1565c0"></span>
+          <span>
+            <span class="swatch__name">Azul transporte</span><br />
+            <span class="swatch__hex">#1565C0</span>
+          </span>
+        </div>
+        <div class="swatch">
+          <span class="swatch__chip" style="background: #c8bfa8"></span>
+          <span>
+            <span class="swatch__name">Borda</span><br />
+            <span class="swatch__hex">#C8BFA8</span>
+          </span>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>A regra que segura o sistema</h3>
+        <p>
+          Nenhum tom fora dessas 8. Precisou de variação? <strong>Deriva em oklch</strong> a partir
+          do token — não inventa um hex novo.
+        </p>
+      </div>
+    </section>
+
+    <!-- 3 ------------------------------------------------------------- -->
+    <section class="slide" data-n="3">
+      <p class="eyebrow">Dois temas</p>
+      <h2>O escuro troca os tiles do mapa</h2>
+      <div class="shots">
+        <div>
+          <p class="shot-label" style="color: var(--green)">Ciclovia</p>
+          <img class="shot" src="../exports/07-home-mobile-ciclovia.png" alt="Tema Ciclovia" />
+        </div>
+        <div>
+          <p class="shot-label" style="color: var(--asphalt-58)">Noturno</p>
+          <img class="shot" src="../exports/08-home-mobile-noturno.png" alt="Tema Noturno" />
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <p style="font-size: 31px">
+        Não basta escurecer a interface. Interface escura com um mapa claro estourando no meio da
+        tela é <strong>pior</strong> que não ter tema escuro.
+      </p>
+    </section>
+
+    <!-- 4 ------------------------------------------------------------- -->
+    <section class="slide slide--paper" data-n="4">
+      <p class="eyebrow">Signature moves</p>
+      <h2>O que dá identidade</h2>
+      <div class="list">
+        <div class="item">
+          <span class="item__mark">→</span>
+          <div class="item__body">
+            <h3>Sombra dura, blur zero</h3>
+            <p>Deslocada e sólida. Parece placa impressa, não Material Design.</p>
+          </div>
+        </div>
+        <div class="item">
+          <span class="item__mark">→</span>
+          <div class="item__body">
+            <h3>CTA em paralelogramo</h3>
+            <p>Cortado com <code>clip-path</code>. É o herói do próximo slide.</p>
+          </div>
+        </div>
+        <div class="item">
+          <span class="item__mark">→</span>
+          <div class="item__body">
+            <h3>Trilho verde de 5px</h3>
+            <p>Na lateral do card. Sinaliza seleção sem precisar de cor de fundo.</p>
+          </div>
+        </div>
+        <div class="item">
+          <span class="item__mark">→</span>
+          <div class="item__body">
+            <h3>Pin teardrop numerado</h3>
+            <p>O selecionado cresce e vira amarelo.</p>
+          </div>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div style="display: flex; align-items: center; gap: 34px">
+        <span class="cta">Sugerir grupo</span>
+        <p style="font-size: 27px; color: var(--asphalt-58)">
+          ← este botão<br />é onde tudo deu errado
+        </p>
+      </div>
+    </section>
+
+    <!-- 5 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="5">
+      <p class="eyebrow">O bug</p>
+      <h2 style="font-size: 58px">
+        <span class="hl-yellow" style="white-space: nowrap">clip-path</span> recorta o
+        <span class="hl-yellow" style="white-space: nowrap">box-shadow</span>
+      </h2>
+      <p class="lead">
+        O hover do CTA amarelo simplesmente não aparecia. A sombra era desenhada e cortada
+        <strong>no mesmo frame</strong>.
+      </p>
+      <p class="lead" style="margin-top: 24px">
+        Sobrava só o deslocamento de 2px. Imperceptível.
+      </p>
+      <div class="spacer"></div>
+      <div class="code">
+<span class="c">/* o elemento é cortado em paralelogramo... */</span>
+.ps-cta {
+  <span class="k">clip-path</span>: polygon(16px 0, 100% 0, ...);
+}
+
+<span class="c">/* ...e a sombra do hover nasce já cortada */</span>
+.ps-cta:hover {
+  <span class="k">box-shadow</span>: 4px 4px 0 var(--green); <span class="c">/* ✗ */</span>
+}</div>
+      <div class="spacer"></div>
+      <p class="footer-note">
+        Recorte e sombra vivem em estágios diferentes do pipeline de pintura.
+      </p>
+    </section>
+
+    <!-- 6 ------------------------------------------------------------- -->
+    <section class="slide" data-n="6">
+      <p class="eyebrow">Duas tentativas</p>
+      <h2>A primeira correção também falhou</h2>
+      <div class="compare">
+        <div class="compare__cell compare__cell--bad">
+          <p class="compare__tag">✗ Tentativa 1</p>
+          <h3 style="margin-bottom: 12px">filter: drop-shadow()</h3>
+          <p>
+            Aplicado <em>depois</em> do recorte — deveria funcionar. Mas não renderiza sobre
+            <code>clip-path</code> em alguns navegadores.
+          </p>
+        </div>
+        <div class="compare__cell compare__cell--good">
+          <p class="compare__tag">✓ Solução</p>
+          <h3 style="margin-bottom: 12px">Camadas na mão</h3>
+          <p>
+            Parar de pedir sombra ao browser e construir a camada como elemento real.
+          </p>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="code">
+.ps-cta {
+  <span class="k">isolation</span>: isolate; <span class="c">/* escopa o z-index negativo */</span>
+}
+.ps-cta::after  { <span class="c">/* face amarela          */</span> }
+.ps-cta::before { <span class="c">/* bloco verde atrás dela */</span>
+  <span class="k">z-index</span>: -1;
+}
+.ps-cta:hover::before {
+  <span class="g">transform</span>: translate(4px, 4px); <span class="c">/* ✓ desliza */</span>
+}</div>
+      <div class="spacer"></div>
+      <p class="footer-note">Sem filter. Sem box-shadow recortado. Confiável cross-browser.</p>
+    </section>
+
+    <!-- 7 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="7">
+      <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
+      <div class="spacer"></div>
+      <p class="eyebrow">A lição</p>
+      <h2 style="font-size: 58px">
+        Quando você corta um elemento, corta <span class="hl-yellow">tudo</span> que ele desenha
+      </h2>
+      <p class="lead">
+        Inclusive o que você queria que vazasse para fora dele.
+      </p>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Mapa colaborativo dos grupos de pedal de SP</h3>
+        <p style="margin-top: 10px">
+          pedalasampa.netlify.app<br />
+          github.com/adams-alves-dev/pedala-sampa
+        </p>
+      </div>
+    </section>
+
+    <script>
+      // ?slide=N exibe só o slide N — facilita capturar um por vez em 1080×1350
+      const n = new URLSearchParams(location.search).get('slide')
+      if (n) {
+        document.querySelectorAll('.slide').forEach((s) => {
+          if (s.dataset.n !== n) s.remove()
+        })
+        // sem padding/scrollbar: a página passa a ter exatamente 1080×1350,
+        // então `take_screenshot --fullPage` sai no tamanho certo
+        document.body.style.cssText += ';padding:0;gap:0;overflow:hidden;'
+        document.documentElement.style.overflow = 'hidden'
+      }
+    </script>
+  </body>
+</html>

--- a/docs/marketing/linkedin/slides/post-2-slides.html
+++ b/docs/marketing/linkedin/slides/post-2-slides.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
   <head>
     <meta charset="utf-8" />
-    <title>Post 2 — Design & frontend | Slides</title>
+    <title>Post 2 — O design system | Slides</title>
     <link rel="stylesheet" href="_base.css" />
   </head>
   <body>
@@ -11,9 +11,9 @@
       <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
       <div class="spacer"></div>
       <p class="eyebrow">Design system</p>
-      <h1>Um design system que parece <span class="hl-yellow">placa de rua</span></h1>
+      <h1>8 cores.<br />E não entra uma <span class="hl-yellow">nona</span>.</h1>
       <p class="lead" style="margin-top: 44px">
-        E o bug de CSS que me custou <strong>7 commits</strong> para acertar um estado de hover.
+        Uma restrição chata de propósito — e o que ela resolve.
       </p>
       <div class="spacer"></div>
       <span class="cta">Arraste →</span>
@@ -21,8 +21,8 @@
 
     <!-- 2 ------------------------------------------------------------- -->
     <section class="slide" data-n="2">
-      <p class="eyebrow">A base</p>
-      <h2>O sistema inteiro cabe em 8 cores</h2>
+      <p class="eyebrow">A paleta inteira</p>
+      <h2>Oito tokens core</h2>
       <div class="swatches">
         <div class="swatch">
           <span class="swatch__chip" style="background: #1a120b"></span>
@@ -48,28 +48,28 @@
         <div class="swatch">
           <span class="swatch__chip" style="background: #00796b"></span>
           <span>
-            <span class="swatch__name">Verde ciclovia</span><br />
+            <span class="swatch__name">Verde</span><br />
             <span class="swatch__hex">#00796B</span>
           </span>
         </div>
         <div class="swatch">
           <span class="swatch__chip" style="background: #ffb300"></span>
           <span>
-            <span class="swatch__name">Amarelo placa</span><br />
+            <span class="swatch__name">Amarelo</span><br />
             <span class="swatch__hex">#FFB300</span>
           </span>
         </div>
         <div class="swatch">
           <span class="swatch__chip" style="background: #e53935"></span>
           <span>
-            <span class="swatch__name">Vermelho alerta</span><br />
+            <span class="swatch__name">Vermelho</span><br />
             <span class="swatch__hex">#E53935</span>
           </span>
         </div>
         <div class="swatch">
           <span class="swatch__chip" style="background: #1565c0"></span>
           <span>
-            <span class="swatch__name">Azul transporte</span><br />
+            <span class="swatch__name">Azul</span><br />
             <span class="swatch__hex">#1565C0</span>
           </span>
         </div>
@@ -83,18 +83,56 @@
       </div>
       <div class="spacer"></div>
       <div class="card">
-        <h3>A regra que segura o sistema</h3>
+        <h3>Precisou de um tom que não existe?</h3>
         <p>
-          Nenhum tom fora dessas 8. Precisou de variação? <strong>Deriva em oklch</strong> a partir
-          do token — não inventa um hex novo.
+          <strong>Deriva em oklch</strong> a partir de um dos 8. Não inventa um hex novo.
         </p>
       </div>
+      <div class="spacer"></div>
+      <p class="footer-note">
+        É o que impede a paleta de virar 40 cores com quatro cinzas quase iguais.
+      </p>
     </section>
 
     <!-- 3 ------------------------------------------------------------- -->
-    <section class="slide" data-n="3">
-      <p class="eyebrow">Dois temas</p>
-      <h2>O escuro troca os tiles do mapa</h2>
+    <section class="slide slide--paper" data-n="3">
+      <p class="eyebrow">O que mais o sistema fecha</p>
+      <h2>Pouca escolha, de propósito</h2>
+      <div class="rows">
+        <div class="row">
+          <span class="row__v">Tipo</span>
+          <span class="row__t">Escala fechada, de 11px a um clamp que chega a 80px</span>
+        </div>
+        <div class="row">
+          <span class="row__v">Espaço</span>
+          <span class="row__t">Base 4px — de 4 a 64</span>
+        </div>
+        <div class="row">
+          <span class="row__v">Raio</span>
+          <span class="row__t">Dois. 4px e 6px.</span>
+        </div>
+        <div class="row">
+          <span class="row__v">Sombra</span>
+          <span class="row__t">
+            Duas: a de placa (4px 4px 0, sem blur) e a de painel (essa sim, difusa)
+          </span>
+        </div>
+        <div class="row">
+          <span class="row__v">Fonte</span>
+          <span class="row__t">Archivo para display, Hanken Grotesk para corpo</span>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <p class="lead">
+        Sistema pequeno não é sistema pobre. É sistema que alguém consegue seguir
+        <strong>sem consultar documentação</strong> toda vez.
+      </p>
+    </section>
+
+    <!-- 4 ------------------------------------------------------------- -->
+    <section class="slide" data-n="4">
+      <p class="eyebrow">Tema é override de token</p>
+      <h2>Nenhum componente sabe que existe tema</h2>
       <div class="shots">
         <div>
           <p class="shot-label" style="color: var(--green)">Ciclovia</p>
@@ -107,132 +145,52 @@
       </div>
       <div class="spacer"></div>
       <p style="font-size: 31px">
-        Não basta escurecer a interface. Interface escura com um mapa claro estourando no meio da
-        tela é <strong>pior</strong> que não ter tema escuro.
+        Trocar de um para outro não passa por componente nenhum — passa por um bloco de variáveis
+        CSS. E o escuro <strong>troca os tiles do mapa</strong> junto.
       </p>
-    </section>
-
-    <!-- 4 ------------------------------------------------------------- -->
-    <section class="slide slide--paper" data-n="4">
-      <p class="eyebrow">Signature moves</p>
-      <h2>O que dá identidade</h2>
-      <div class="list">
-        <div class="item">
-          <span class="item__mark">→</span>
-          <div class="item__body">
-            <h3>Sombra dura, blur zero</h3>
-            <p>Deslocada e sólida. Parece placa impressa, não Material Design.</p>
-          </div>
-        </div>
-        <div class="item">
-          <span class="item__mark">→</span>
-          <div class="item__body">
-            <h3>CTA em paralelogramo</h3>
-            <p>Cortado com <code>clip-path</code>. É o herói do próximo slide.</p>
-          </div>
-        </div>
-        <div class="item">
-          <span class="item__mark">→</span>
-          <div class="item__body">
-            <h3>Trilho verde de 5px</h3>
-            <p>Na lateral do card. Sinaliza seleção sem precisar de cor de fundo.</p>
-          </div>
-        </div>
-        <div class="item">
-          <span class="item__mark">→</span>
-          <div class="item__body">
-            <h3>Pin teardrop numerado</h3>
-            <p>O selecionado cresce e vira amarelo.</p>
-          </div>
-        </div>
-      </div>
-      <div class="spacer"></div>
-      <div style="display: flex; align-items: center; gap: 34px">
-        <span class="cta">Sugerir grupo</span>
-        <p style="font-size: 27px; color: var(--asphalt-58)">
-          ← este botão<br />é onde tudo deu errado
-        </p>
-      </div>
     </section>
 
     <!-- 5 ------------------------------------------------------------- -->
     <section class="slide slide--dark" data-n="5">
-      <p class="eyebrow">O bug</p>
-      <h2 style="font-size: 58px">
-        <span class="hl-yellow" style="white-space: nowrap">clip-path</span> recorta o
-        <span class="hl-yellow" style="white-space: nowrap">box-shadow</span>
-      </h2>
-      <p class="lead">
-        O hover do CTA amarelo simplesmente não aparecia. A sombra era desenhada e cortada
-        <strong>no mesmo frame</strong>.
-      </p>
-      <p class="lead" style="margin-top: 24px">
-        Sobrava só o deslocamento de 2px. Imperceptível.
-      </p>
+      <p class="eyebrow">O corte</p>
+      <h2>Explorou 6. Foram 2.</h2>
+      <div class="stats">
+        <div class="stat">
+          <p class="stat__n">6 → 2</p>
+          <p class="stat__label">temas explorados → em produção</p>
+        </div>
+        <div class="stat">
+          <p class="stat__n">5 → 1</p>
+          <p class="stat__label">pares de fonte → em produção</p>
+        </div>
+      </div>
       <div class="spacer"></div>
-      <div class="code">
-<span class="c">/* o elemento é cortado em paralelogramo... */</span>
-.ps-cta {
-  <span class="k">clip-path</span>: polygon(16px 0, 100% 0, ...);
-}
-
-<span class="c">/* ...e a sombra do hover nasce já cortada */</span>
-.ps-cta:hover {
-  <span class="k">box-shadow</span>: 4px 4px 0 var(--green); <span class="c">/* ✗ */</span>
-}</div>
+      <div class="card">
+        <h3>E o painel de tweaks?</h3>
+        <p>Ajustava os tokens ao vivo. Estava pronto. <strong>Não foi.</strong></p>
+      </div>
+      <div class="spacer"></div>
+      <p class="lead">
+        Explorar seis e escolher dois não é desperdício — é como você descobre que
+        <strong>dois bastam</strong>.
+      </p>
       <div class="spacer"></div>
       <p class="footer-note">
-        Recorte e sombra vivem em estágios diferentes do pipeline de pintura.
+        O desperdício seria implementar os seis porque já estavam prontos.
       </p>
     </section>
 
     <!-- 6 ------------------------------------------------------------- -->
-    <section class="slide" data-n="6">
-      <p class="eyebrow">Duas tentativas</p>
-      <h2>A primeira correção também falhou</h2>
-      <div class="compare">
-        <div class="compare__cell compare__cell--bad">
-          <p class="compare__tag">✗ Tentativa 1</p>
-          <h3 style="margin-bottom: 12px">filter: drop-shadow()</h3>
-          <p>
-            Aplicado <em>depois</em> do recorte — deveria funcionar. Mas não renderiza sobre
-            <code>clip-path</code> em alguns navegadores.
-          </p>
-        </div>
-        <div class="compare__cell compare__cell--good">
-          <p class="compare__tag">✓ Solução</p>
-          <h3 style="margin-bottom: 12px">Camadas na mão</h3>
-          <p>
-            Parar de pedir sombra ao browser e construir a camada como elemento real.
-          </p>
-        </div>
-      </div>
-      <div class="spacer"></div>
-      <div class="code">
-.ps-cta {
-  <span class="k">isolation</span>: isolate; <span class="c">/* escopa o z-index negativo */</span>
-}
-.ps-cta::after  { <span class="c">/* face amarela          */</span> }
-.ps-cta::before { <span class="c">/* bloco verde atrás dela */</span>
-  <span class="k">z-index</span>: -1;
-}
-.ps-cta:hover::before {
-  <span class="g">transform</span>: translate(4px, 4px); <span class="c">/* ✓ desliza */</span>
-}</div>
-      <div class="spacer"></div>
-      <p class="footer-note">Sem filter. Sem box-shadow recortado. Confiável cross-browser.</p>
-    </section>
-
-    <!-- 7 ------------------------------------------------------------- -->
-    <section class="slide slide--dark" data-n="7">
+    <section class="slide slide--dark" data-n="6">
       <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
       <div class="spacer"></div>
-      <p class="eyebrow">A lição</p>
+      <p class="eyebrow">O ponto</p>
       <h2 style="font-size: 58px">
-        Quando você corta um elemento, corta <span class="hl-yellow">tudo</span> que ele desenha
+        O handoff não foi um Figma.<br />Foi <span class="hl-yellow">código que roda</span>.
       </h2>
       <p class="lead">
-        Inclusive o que você queria que vazasse para fora dele.
+        Tokens, componentes e uma página de showcase, tudo no browser. Não tem "mas no Figma o
+        espaçamento era outro" — a referência é executável.
       </p>
       <div class="spacer"></div>
       <div class="card">
@@ -245,7 +203,6 @@
     </section>
 
     <script>
-      // ?slide=N exibe só o slide N — facilita capturar um por vez em 1080×1350
       const n = new URLSearchParams(location.search).get('slide')
       if (n) {
         document.querySelectorAll('.slide').forEach((s) => {

--- a/docs/marketing/linkedin/slides/post-3-slides.html
+++ b/docs/marketing/linkedin/slides/post-3-slides.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <title>Post 3 — Arquitetura | Slides</title>
+    <link rel="stylesheet" href="_base.css" />
+  </head>
+  <body>
+    <!-- 1 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="1">
+      <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
+      <div class="spacer"></div>
+      <p class="eyebrow">Arquitetura</p>
+      <h1>Prerender é rápido.<br />Também é uma <span class="hl-yellow">foto congelada</span>.</h1>
+      <p class="lead" style="margin-top: 44px">
+        Por que um grupo novo no CMS dá <strong>404</strong> — e por que isso não é bug.
+      </p>
+      <div class="spacer"></div>
+      <span class="cta">Arraste →</span>
+    </section>
+
+    <!-- 2 ------------------------------------------------------------- -->
+    <section class="slide" data-n="2">
+      <p class="eyebrow">Os dois caminhos do dado</p>
+      <h2>Leitura vai direto. Escrita, nunca.</h2>
+      <div class="stack">
+        <div class="card">
+          <h3>Leitura</h3>
+          <p>browser → CMS</p>
+          <p style="margin-top: 14px; font-size: 27px; color: var(--asphalt-58)">
+            Endpoint público, token read-only. Não precisa de servidor no meio.
+          </p>
+        </div>
+        <div class="card" style="border-left-color: var(--yellow)">
+          <h3>Escrita</h3>
+          <p>browser → <strong>server route</strong> → CMS</p>
+          <p style="margin-top: 14px; font-size: 27px; color: var(--asphalt-58)">
+            Todo POST passa por uma função. Sempre.
+          </p>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="code">
+<span class="c">// composables/useSuggestions.ts</span>
+<span class="c">// o token de escrita NÃO pode existir no bundle</span>
+<span class="c">// do client — por isso nunca vai direto ao CMS</span></div>
+      <div class="spacer"></div>
+      <p class="footer-note">
+        A regra está escrita como comentário, para ninguém "otimizar" isso depois.
+      </p>
+    </section>
+
+    <!-- 3 ------------------------------------------------------------- -->
+    <section class="slide slide--paper" data-n="3">
+      <p class="eyebrow">O problema</p>
+      <h2>Ele descobriu as rotas <span class="hl-red">no build</span></h2>
+      <p class="lead">
+        O Nuxt roda o prerender com <strong>crawlLinks</strong>: começa na home, segue todos os
+        links e gera um HTML para cada rota que encontrou.
+      </p>
+      <div class="spacer"></div>
+      <div class="flow">
+        <div class="flow__step">
+          <span class="flow__n">1</span>
+          <span class="flow__t">Build roda. Crawler visita a home e segue os links.</span>
+        </div>
+        <p class="flow__arrow">↓</p>
+        <div class="flow__step">
+          <span class="flow__n">2</span>
+          <span class="flow__t">Um HTML é gerado por rota descoberta. Site no ar, rápido.</span>
+        </div>
+        <p class="flow__arrow">↓</p>
+        <div class="flow__step" style="border-color: var(--red); background: rgb(216 67 47 / 8%)">
+          <span class="flow__n" style="background: var(--red)">3</span>
+          <span class="flow__t">
+            Grupo novo publicado no CMS. O crawler nunca passou por essa rota.
+          </span>
+        </div>
+        <p class="flow__arrow">↓</p>
+        <div class="flow__step" style="border-color: var(--red); background: rgb(216 67 47 / 8%)">
+          <span class="flow__n" style="background: var(--red)">4</span>
+          <span class="flow__t"><strong>404.</strong> O arquivo não existe no dist.</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- 4 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="4">
+      <p class="eyebrow">A solução</p>
+      <h2 style="font-size: 58px">
+        E ela <span class="hl-yellow">não está</span> no repositório
+      </h2>
+      <div class="flow">
+        <div class="flow__step" style="background: rgb(220 231 218 / 10%); border-color: var(--concrete)">
+          <span class="flow__n" style="background: var(--yellow); color: var(--asphalt)">1</span>
+          <span class="flow__t" style="color: var(--concrete)">Conteúdo publicado no Hygraph</span>
+        </div>
+        <p class="flow__arrow" style="color: rgb(220 231 218 / 46%)">↓</p>
+        <div class="flow__step" style="background: rgb(220 231 218 / 10%); border-color: var(--concrete)">
+          <span class="flow__n" style="background: var(--yellow); color: var(--asphalt)">2</span>
+          <span class="flow__t" style="color: var(--concrete)">
+            Webhook dispara o <strong>build hook</strong> da Netlify
+          </span>
+        </div>
+        <p class="flow__arrow" style="color: rgb(220 231 218 / 46%)">↓</p>
+        <div class="flow__step" style="background: rgb(220 231 218 / 10%); border-color: var(--concrete)">
+          <span class="flow__n" style="background: var(--yellow); color: var(--asphalt)">3</span>
+          <span class="flow__t" style="color: var(--concrete)">
+            Build roda de novo. Agora a rota existe.
+          </span>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Por que virou documentação</h3>
+        <p>
+          É infraestrutura invisível no código e <strong>requisito absoluto</strong> de
+          funcionamento. Exatamente o tipo de coisa que some quando alguém assume o projeto.
+        </p>
+      </div>
+    </section>
+
+    <!-- 5 ------------------------------------------------------------- -->
+    <section class="slide" data-n="5">
+      <p class="eyebrow">Cache</p>
+      <h2>Cada miss custa uma chamada autenticada</h2>
+      <div class="code">
+<span class="c">// server/api/groups/[slug].get.ts</span>
+setResponseHeader(event, <span class="g">'Cache-Control'</span>,
+  <span class="g">'public, max-age=60, s-maxage=300,</span>
+<span class="g">   stale-while-revalidate=600'</span>
+)</div>
+      <div class="spacer"></div>
+      <div class="stack">
+        <div class="card">
+          <h3>max-age=60</h3>
+          <p>O formulário de correção não precisa de dado fresquíssimo.</p>
+        </div>
+        <div class="card">
+          <h3>s-maxage=300</h3>
+          <p>O CDN segura por 5 minutos e absorve o pico.</p>
+        </div>
+        <div class="card">
+          <h3>stale-while-revalidate=600</h3>
+          <p>Ninguém espera revalidação. Serve o velho, atualiza atrás.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- 6 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="6">
+      <p class="eyebrow">Leaflet × SSR</p>
+      <h2>Duas armadilhas que custaram tempo</h2>
+      <div class="list">
+        <div class="item">
+          <span class="item__mark">1</span>
+          <div class="item__body">
+            <h3 style="color: var(--concrete)">Import como valor quebra o SSR</h3>
+            <p>
+              O Leaflet toca em <code>window</code> na avaliação do módulo. No escopo do módulo só
+              entram <strong>tipos</strong>; o import real é tardio.
+            </p>
+          </div>
+        </div>
+        <div class="item">
+          <span class="item__mark">2</span>
+          <div class="item__body">
+            <h3 style="color: var(--concrete)">Estilo do pin não pode ser scoped</h3>
+            <p>
+              O Leaflet renderiza marcadores <strong>fora</strong> da árvore do componente. O
+              atributo de escopo do Vue nunca chega neles.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Se eu mudasse uma coisa hoje</h3>
+        <p>
+          Trocar o rebuild inteiro por <strong>ISR via routeRules</strong>. Publicar um grupo não
+          deveria custar um build do site todo.
+        </p>
+        <p style="margin-top: 18px; font-size: 27px">
+          pedalasampa.netlify.app<br />
+          github.com/adams-alves-dev/pedala-sampa
+        </p>
+      </div>
+    </section>
+
+    <script>
+      const n = new URLSearchParams(location.search).get('slide')
+      if (n) {
+        document.querySelectorAll('.slide').forEach((s) => {
+          if (s.dataset.n !== n) s.remove()
+        })
+        document.body.style.cssText += ';padding:0;gap:0;overflow:hidden;'
+        document.documentElement.style.overflow = 'hidden'
+      }
+    </script>
+  </body>
+</html>

--- a/docs/marketing/linkedin/slides/post-4-slides.html
+++ b/docs/marketing/linkedin/slides/post-4-slides.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <title>Post 4 — Comunidade & segurança | Slides</title>
+    <link rel="stylesheet" href="_base.css" />
+  </head>
+  <body>
+    <!-- 1 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="1">
+      <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
+      <div class="spacer"></div>
+      <p class="eyebrow">Segurança</p>
+      <h1>Um formulário aberto na internet é um <span class="hl-yellow">alvo</span></h1>
+      <p class="lead" style="margin-top: 44px">
+        Sem login, sem conta, sem e-mail de confirmação.<br />
+        <strong>4 camadas</strong> para não virar depósito de spam.
+      </p>
+      <div class="spacer"></div>
+      <span class="cta">Arraste →</span>
+    </section>
+
+    <!-- 2 ------------------------------------------------------------- -->
+    <section class="slide" data-n="2">
+      <p class="eyebrow">A decisão</p>
+      <h2>Pedir cadastro mataria a contribuição</h2>
+      <p class="lead">
+        Quem tem a informação certa é quem <strong>organiza o pedal</strong>.
+      </p>
+      <p class="lead" style="margin-top: 26px">
+        E essa pessoa não vai criar uma conta num site que ela nunca viu para consertar o horário de
+        saída dela.
+      </p>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Ou é fácil, ou não acontece</h3>
+        <p>
+          Então a fricção saiu do usuário e foi para as <strong>camadas de trás</strong>.
+        </p>
+      </div>
+    </section>
+
+    <!-- 3 ------------------------------------------------------------- -->
+    <section class="slide slide--paper" data-n="3">
+      <p class="eyebrow">Camada 1</p>
+      <h2>Honeypot: o 200 mentiroso</h2>
+      <div class="code">
+<span class="c">// server/api/suggestions.post.ts</span>
+<span class="c">// bots preenchem o campo escondido;</span>
+<span class="c">// respondemos 200 sem criar nada</span>
+<span class="k">if</span> (body?.website) {
+  <span class="k">return</span> { ok: <span class="g">true</span>, id: <span class="g">'ok'</span> }
+}</div>
+      <div class="spacer"></div>
+      <p class="lead">
+        Um campo escondido no formulário. Humano não vê, bot preenche.
+      </p>
+      <p class="lead" style="margin-top: 24px">
+        A API responde <strong>200 e não cria nada</strong>. O bot registra sucesso e vai embora
+        feliz.
+      </p>
+      <div class="spacer"></div>
+      <p class="footer-note">Custa 3 linhas e resolve o bot mais simples.</p>
+    </section>
+
+    <!-- 4 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="4">
+      <p class="eyebrow">A ordem importa</p>
+      <h2 style="font-size: 56px">
+        O Zod roda <span class="hl-yellow">antes</span> do Turnstile
+      </h2>
+      <div class="compare">
+        <div class="compare__cell compare__cell--bad">
+          <p class="compare__tag">✗ Ordem errada</p>
+          <p>
+            Checa o desafio → descobre que faltou um campo → devolve 400.<br /><br />
+            O token <strong>já foi queimado</strong>. O reenvio corrigido falha.
+          </p>
+        </div>
+        <div class="compare__cell compare__cell--good">
+          <p class="compare__tag">✓ Ordem certa</p>
+          <p>
+            Valida os campos → só então checa o desafio.<br /><br />
+            Um 400 de validação <strong>não consome</strong> o token.
+          </p>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Por quê</h3>
+        <p>
+          O token do Turnstile é de <strong>uso único</strong>. Na ordem errada, a pessoa preenche
+          tudo de novo e leva erro de novo — estando certa.
+        </p>
+      </div>
+      <div class="spacer"></div>
+      <p class="footer-note">Ordem errada não quebra o teste. Quebra o usuário honesto.</p>
+    </section>
+
+    <!-- 5 ------------------------------------------------------------- -->
+    <section class="slide" data-n="5">
+      <p class="eyebrow">Honestidade</p>
+      <h2>O comentário que deixei no código</h2>
+      <div class="code">
+<span class="c">/**</span>
+<span class="c"> * Rate limit simples por IP, em memória.</span>
+<span class="c"> *</span>
+<span class="c"> * Limitação conhecida: em ambiente serverless</span>
+<span class="c"> * cada instância tem sua própria memória e</span>
+<span class="c"> * instâncias são recicladas, então o limite</span>
+<span class="c"> * vale por instância — é uma barreira contra</span>
+<span class="c"> * rajadas, NÃO uma garantia global.</span>
+<span class="c"> */</span></div>
+      <div class="spacer"></div>
+      <p class="lead">
+        Junto vai a evolução sugerida: Redis compartilhado.
+      </p>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Defesa que você não sabe onde falha</h3>
+        <p>não é defesa. É <strong>sorte</strong>.</p>
+      </div>
+    </section>
+
+    <!-- 6 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="6">
+      <p class="eyebrow">Curadoria</p>
+      <h2>Nenhuma automação minha publica</h2>
+      <div class="stack">
+        <div class="card">
+          <h3 style="color: var(--concrete)">Dois tokens, não um</h3>
+          <p>O público é read-only. A CLI de curadoria usa outro, separado.</p>
+        </div>
+        <div class="card" style="border-left-color: var(--yellow)">
+          <h3 style="color: var(--concrete)">Sem permissão de publish</h3>
+          <p>De propósito. O máximo que a automação faz é criar <strong>rascunho</strong>.</p>
+        </div>
+        <div class="card">
+          <h3 style="color: var(--concrete)">Publicar é humano</h3>
+          <p>No CMS, com o conteúdo na frente.</p>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <p class="lead">
+        Quando a única forma de ir ao ar é alguém clicando, o pior caso de um bug na automação é
+        <strong>rascunho sujo</strong> — nunca conteúdo errado em produção.
+      </p>
+    </section>
+
+    <!-- 7 ------------------------------------------------------------- -->
+    <section class="slide" data-n="7">
+      <p class="eyebrow">Discord & LGPD</p>
+      <h2>Dado de terceiro é responsabilidade</h2>
+      <div class="list">
+        <div class="item">
+          <span class="item__mark">→</span>
+          <div class="item__body">
+            <h3>allowed_mentions vazio</h3>
+            <p>Texto livre de desconhecido não vai pingar @everyone no meu servidor.</p>
+          </div>
+        </div>
+        <div class="item">
+          <span class="item__mark">→</span>
+          <div class="item__body">
+            <h3>Timeout de 3s, best-effort</h3>
+            <p>Se o Discord cair, a sugestão é salva do mesmo jeito.</p>
+          </div>
+        </div>
+        <div class="item">
+          <span class="item__mark">→</span>
+          <div class="item__body">
+            <h3>Canal privado, documentado</h3>
+            <p>O aviso carrega o e-mail de quem contribuiu.</p>
+          </div>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>A notificação é minha conveniência</h3>
+        <p>não parte do contrato com quem contribuiu.</p>
+        <p style="margin-top: 18px; font-size: 27px">
+          pedalasampa.netlify.app<br />
+          github.com/adams-alves-dev/pedala-sampa
+        </p>
+      </div>
+    </section>
+
+    <script>
+      const n = new URLSearchParams(location.search).get('slide')
+      if (n) {
+        document.querySelectorAll('.slide').forEach((s) => {
+          if (s.dataset.n !== n) s.remove()
+        })
+        document.body.style.cssText += ';padding:0;gap:0;overflow:hidden;'
+        document.documentElement.style.overflow = 'hidden'
+      }
+    </script>
+  </body>
+</html>

--- a/docs/marketing/linkedin/slides/post-5-slides.html
+++ b/docs/marketing/linkedin/slides/post-5-slides.html
@@ -11,38 +11,26 @@
       <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
       <div class="spacer"></div>
       <p class="eyebrow">Processo</p>
-      <h1>4 anos parado.<br /><span class="hl-yellow">5 versões</span> em 8 dias.</h1>
-      <div style="margin-top: 56px">
-        <div class="rows" style="background: rgb(220 231 218 / 8%); border-color: var(--concrete)">
-          <div class="row" style="border-color: rgb(220 231 218 / 25%)">
-            <span class="row__v" style="color: var(--yellow)">set/2021</span>
-            <span class="row__t" style="color: var(--concrete)">
-              Último commit. Um app Nuxt 2 que funcionava e que eu abandonei.
-            </span>
-          </div>
-          <div class="row" style="border-color: rgb(220 231 218 / 25%)">
-            <span class="row__v" style="color: rgb(220 231 218 / 46%)">···</span>
-            <span class="row__t" style="color: rgb(220 231 218 / 55%)">
-              4 anos e 8 meses de silêncio
-            </span>
-          </div>
-          <div class="row">
-            <span class="row__v" style="color: var(--yellow)">jun/2026</span>
-            <span class="row__t" style="color: var(--concrete)">
-              Um PR troca Nuxt 2 por Nuxt 3 + TypeScript strict, com o redesign junto.
-            </span>
-          </div>
-        </div>
-      </div>
+      <h1><span class="hl-yellow">5 versões</span><br />em 8 dias.</h1>
+      <p class="lead" style="margin-top: 44px">
+        E eu não escrevi um changelog sequer.<br />
+        Nem escolhi nenhum número de versão.
+      </p>
       <div class="spacer"></div>
-      <p class="lead">A diferença não foi disposição. Foi <strong>tooling</strong>.</p>
+      <div class="card">
+        <h3 style="color: var(--concrete)">Não é preguiça</h3>
+        <p>
+          É o ponto. Num projeto solo, a coisa mais fácil do mundo é pular processo — então montei o
+          <strong>tooling antes das features</strong>.
+        </p>
+      </div>
       <div class="spacer"></div>
       <span class="cta">Arraste →</span>
     </section>
 
     <!-- 2 ------------------------------------------------------------- -->
     <section class="slide" data-n="2">
-      <p class="eyebrow">11 a 18 de junho de 2026</p>
+      <p class="eyebrow">O que saiu na semana</p>
       <h2>Cinco releases em oito dias</h2>
       <div class="rows">
         <div class="row">

--- a/docs/marketing/linkedin/slides/post-5-slides.html
+++ b/docs/marketing/linkedin/slides/post-5-slides.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <title>Post 5 — Processo & entrega | Slides</title>
+    <link rel="stylesheet" href="_base.css" />
+  </head>
+  <body>
+    <!-- 1 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="1">
+      <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
+      <div class="spacer"></div>
+      <p class="eyebrow">Processo</p>
+      <h1>4 anos parado.<br /><span class="hl-yellow">5 versões</span> em 8 dias.</h1>
+      <div style="margin-top: 56px">
+        <div class="rows" style="background: rgb(220 231 218 / 8%); border-color: var(--concrete)">
+          <div class="row" style="border-color: rgb(220 231 218 / 25%)">
+            <span class="row__v" style="color: var(--yellow)">set/2021</span>
+            <span class="row__t" style="color: var(--concrete)">
+              Último commit. Um app Nuxt 2 que funcionava e que eu abandonei.
+            </span>
+          </div>
+          <div class="row" style="border-color: rgb(220 231 218 / 25%)">
+            <span class="row__v" style="color: rgb(220 231 218 / 46%)">···</span>
+            <span class="row__t" style="color: rgb(220 231 218 / 55%)">
+              4 anos e 8 meses de silêncio
+            </span>
+          </div>
+          <div class="row">
+            <span class="row__v" style="color: var(--yellow)">jun/2026</span>
+            <span class="row__t" style="color: var(--concrete)">
+              Um PR troca Nuxt 2 por Nuxt 3 + TypeScript strict, com o redesign junto.
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <p class="lead">A diferença não foi disposição. Foi <strong>tooling</strong>.</p>
+      <div class="spacer"></div>
+      <span class="cta">Arraste →</span>
+    </section>
+
+    <!-- 2 ------------------------------------------------------------- -->
+    <section class="slide" data-n="2">
+      <p class="eyebrow">11 a 18 de junho de 2026</p>
+      <h2>Cinco releases em oito dias</h2>
+      <div class="rows">
+        <div class="row">
+          <span class="row__v">v1.0.0</span>
+          <span class="row__t">Nuxt 3 + redesign no ar</span>
+        </div>
+        <div class="row">
+          <span class="row__v">v1.1.0</span>
+          <span class="row__t">
+            Sugestões da comunidade: criar, corrigir e remover grupo. Ponto de saída pelo mapa.
+          </span>
+        </div>
+        <div class="row">
+          <span class="row__v">v1.2.0</span>
+          <span class="row__t">Ritmo derivado da duração do pedal</span>
+        </div>
+        <div class="row">
+          <span class="row__v">v1.3.0</span>
+          <span class="row__t">
+            CLI de curadoria, avisos no Discord, múltiplas agendas por grupo
+          </span>
+        </div>
+        <div class="row">
+          <span class="row__v">v1.4.0</span>
+          <span class="row__t">Canal de feedback, privacidade e termos</span>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <p class="footer-note">
+        Versão e changelog gerados a partir dos commits. Eu não escrevi nenhum dos dois.
+      </p>
+    </section>
+
+    <!-- 3 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="3">
+      <p class="eyebrow">Onde o projeto está hoje</p>
+      <h2>Os números</h2>
+      <div class="stats">
+        <div class="stat">
+          <p class="stat__n">170</p>
+          <p class="stat__label">casos de teste, em 19 arquivos</p>
+        </div>
+        <div class="stat">
+          <p class="stat__n">21</p>
+          <p class="stat__label">módulos puros em lib/</p>
+        </div>
+        <div class="stat">
+          <p class="stat__n">26</p>
+          <p class="stat__label">componentes Vue</p>
+        </div>
+        <div class="stat">
+          <p class="stat__n">10</p>
+          <p class="stat__label">rotas</p>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>3</h3>
+        <p>
+          server routes. É toda a superfície de backend — o resto é estático.
+        </p>
+      </div>
+    </section>
+
+    <!-- 4 ------------------------------------------------------------- -->
+    <section class="slide slide--paper" data-n="4">
+      <p class="eyebrow">Por que 170 testes foram baratos</p>
+      <h2>A regra de negócio não mora no componente</h2>
+      <div class="compare">
+        <div class="compare__cell compare__cell--bad">
+          <p class="compare__tag">✗ Lógica no componente</p>
+          <p>
+            Montar componente, mockar o CMS, esperar renderização — para testar uma regra de
+            filtro.
+          </p>
+        </div>
+        <div class="compare__cell compare__cell--good">
+          <p class="compare__tag">✓ Lógica em lib/</p>
+          <p>
+            Função pura. Escreve entrada, espera saída. Sem montagem, sem mock, sem espera.
+          </p>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <p class="lead">
+        Filtros, normalizadores, schemas, formatação de tempo: <strong>21 módulos</strong> que não
+        sabem que existe um browser.
+      </p>
+      <p class="lead" style="margin-top: 26px">
+        O componente fica com o que é dele: apresentar.
+      </p>
+      <div class="spacer"></div>
+      <p class="footer-note">
+        Quando testar dói, quase sempre o problema é onde a lógica está — não a ferramenta.
+      </p>
+    </section>
+
+    <!-- 5 ------------------------------------------------------------- -->
+    <section class="slide" data-n="5">
+      <p class="eyebrow">O pipeline</p>
+      <h2>O erro pego antes do CI</h2>
+      <div class="flow">
+        <div class="flow__step flow__step--accent">
+          <span class="flow__n">1</span>
+          <span class="flow__t"><strong>pre-commit</strong> — lint-staged</span>
+        </div>
+        <p class="flow__arrow">↓</p>
+        <div class="flow__step flow__step--accent">
+          <span class="flow__n">2</span>
+          <span class="flow__t"><strong>commit-msg</strong> — commitlint</span>
+        </div>
+        <p class="flow__arrow">↓</p>
+        <div class="flow__step flow__step--accent">
+          <span class="flow__n">3</span>
+          <span class="flow__t"><strong>pre-push</strong> — typecheck</span>
+        </div>
+        <p class="flow__arrow">↓</p>
+        <div class="flow__step">
+          <span class="flow__n">4</span>
+          <span class="flow__t">CI — lint → typecheck → test</span>
+        </div>
+        <p class="flow__arrow">↓</p>
+        <div class="flow__step">
+          <span class="flow__n">5</span>
+          <span class="flow__t">release-please → tag → deploy</span>
+        </div>
+      </div>
+      <div class="spacer"></div>
+      <p class="lead">
+        CI vermelho é feedback <strong>caro</strong>: chega minutos depois, quando você já está em
+        outra coisa.
+      </p>
+      <p class="lead" style="margin-top: 22px">O mesmo erro pego no commit custa 4 segundos.</p>
+    </section>
+
+    <!-- 6 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="6">
+      <p class="eyebrow">A pegadinha</p>
+      <h2 style="font-size: 56px">
+        O <span class="hl-yellow">GITHUB_TOKEN</span> não dispara o próprio workflow
+      </h2>
+      <p class="lead">
+        O release-please abre a PR de release. Ao mergear, deveria rodar o workflow que cria a tag.
+      </p>
+      <p class="lead" style="margin-top: 26px">Não roda.</p>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Por quê</h3>
+        <p>
+          Ação feita com o token do sistema <strong>não gera evento</strong> para o próprio sistema.
+          É proteção contra loop infinito.
+        </p>
+        <p style="margin-top: 16px">A saída é um PAT.</p>
+      </div>
+      <div class="spacer"></div>
+      <p class="footer-note">
+        Depois do release, back-merge automático de main para develop — para as branches não
+        divergirem sozinhas.
+      </p>
+    </section>
+
+    <!-- 7 ------------------------------------------------------------- -->
+    <section class="slide slide--dark" data-n="7">
+      <div class="brand"><span class="brand__pin"></span> Pedala Sampa</div>
+      <div class="spacer"></div>
+      <p class="eyebrow">O ponto</p>
+      <h2 style="font-size: 60px">
+        Ferramenta boa não é a que faz você ir rápido
+      </h2>
+      <p class="lead">
+        É a que faz o <span class="hl-yellow">certo</span> ser o caminho mais fácil.
+      </p>
+      <div class="spacer"></div>
+      <div class="card">
+        <h3>Mapa colaborativo dos grupos de pedal de SP</h3>
+        <p style="margin-top: 10px">
+          pedalasampa.netlify.app<br />
+          github.com/adams-alves-dev/pedala-sampa
+        </p>
+      </div>
+    </section>
+
+    <script>
+      const n = new URLSearchParams(location.search).get('slide')
+      if (n) {
+        document.querySelectorAll('.slide').forEach((s) => {
+          if (s.dataset.n !== n) s.remove()
+        })
+        document.body.style.cssText += ';padding:0;gap:0;overflow:hidden;'
+        document.documentElement.style.overflow = 'hidden'
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## O que é

Material de divulgação do projeto no LinkedIn: **5 posts temáticos**, ênfase 70% técnico / 30% produto — vitrine de engenharia frontend, com o produto servindo de prova de entrega.

Cada post se sustenta sozinho, mas juntos formam uma jornada:

| # | Post | Gancho |
|---|---|---|
| 1 | O produto | "Descobrir qual grupo passa perto de você não existia em lugar nenhum" |
| 2 | Design & frontend | "clip-path recorta o box-shadow" — 7 commits para um hover |
| 3 | Arquitetura | "Prerender é rápido. Também é uma foto congelada." |
| 4 | Comunidade & segurança | "Um formulário aberto na internet é um alvo" |
| 5 | Processo & entrega | "4 anos parado. 5 versões em 8 dias." |

## Estrutura

Cada `post-N-*.md` traz texto pronto para colar (sem markdown, que o LinkedIn não renderiza), uma variante curta, o briefing das imagens e uma **seção de fontes** apontando o arquivo ou commit que sustenta cada afirmação técnica.

Essa seção existe porque post com número errado sobre o próprio projeto é o pior resultado possível. Onde um número envelhece (contagem de commits, grupos no mapa), há aviso explícito para reconferir antes de publicar.

## Slides

Os carrosséis são HTML/CSS em `slides/`, usando os tokens do design system do próprio projeto (tema Ciclovia) — para parecerem parte da marca, não um template genérico. Respeitam as regras do sistema: 8 cores, sombra dura sem blur, CTA em paralelogramo, sem gradiente.

Abrir um deck com `?slide=N` deixa a página em exatamente 1080×1350, o que permite exportar os 27 slides em lote via Chrome headless. Os PNGs (~9 MB) ficam fora do versionamento — o comando para regerar está no README.

## Verificação

- **Overflow**: nenhum dos 27 slides estoura os 1350px.
- **Contraste**: 282 nós de texto auditados, nenhum abaixo de 3:1.
- **Dimensões**: todos os PNGs conferidos em 1080×1350 exatos.
- `yarn lint` e `prettier --check` passando.

Dois problemas reais apareceram nessa verificação e foram corrigidos: células de fundo claro dentro de slide escuro herdavam texto claro e ficavam **invisíveis**, e as notas de rodapé estavam a 2,7:1.

## Fora do escopo

Só documentação — nenhuma mudança em código de aplicação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)