### PR TITLE
docs: adiciona licença MIT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,12 @@ lançamento de releases.
 ## Fluxo de branches
 
 ```
-feature/*  →  develop  →  main (produção, deploy no Netlify)
+feat/* | fix/* | docs/* | chore/*  →  develop  →  main (produção, deploy no Netlify)
 ```
 
 - Trabalhe sempre em uma branch a partir da `develop`.
+- O prefixo da branch acompanha o tipo do Conventional Commit que ela vai gerar
+  (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`…).
 - Nunca faça commit direto na `main` — ela é produção e exige Pull Request.
 - `develop` é a branch de integração; `main` reflete o que está no ar.
 
@@ -102,7 +104,7 @@ Usamos **[SemVer](https://semver.org/)** (`MAJOR.MINOR.PATCH`), partindo de
 
 ### Rotina de lançamento
 
-1. Trabalhe em `feature/*` → PR para **`develop`**.
+1. Trabalhe em uma branch a partir da `develop` → PR para **`develop`**.
 2. **Pronto para publicar: PR `develop` → `main` e mergeie.** Esta é a sua única
    decisão de release.
 3. O push na `main` faz o release-please abrir uma **Release PR** (bump no

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Adams Alves
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Adams Alves
+Copyright (c) 2021-2026 Adams Alves
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Quer adicionar um grupo ou corrigir uma informação? Use o formulário de contr
 
 Quer contribuir com **código**? Veja o **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
+## Licença
+
+Distribuído sob a **[Licença MIT](LICENSE)** — pode usar, modificar e
+redistribuir, inclusive comercialmente, mantendo o aviso de copyright.
+
+A licença cobre o **código**. O conteúdo dos grupos de pedal vem de
+contribuições da comunidade e do CMS, e não faz parte deste repositório.
+
 ## Desenvolvedor :computer:
 
 - **Adams Alves** — [github.com/adamsalves](https://github.com/adamsalves)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pedala-sampa",
   "version": "1.4.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "packageManager": "yarn@1.22.22",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "version": "1.4.0",
   "private": true,
   "license": "MIT",
+  "author": "Adams Alves (https://github.com/adamsalves)",
+  "homepage": "https://pedalasampa.netlify.app",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adams-alves-dev/pedala-sampa.git"
+  },
+  "bugs": {
+    "url": "https://github.com/adams-alves-dev/pedala-sampa/issues"
+  },
   "type": "module",
   "packageManager": "yarn@1.22.22",
   "engines": {


### PR DESCRIPTION
## Contexto

O repositório é público, mas não tinha licença declarada. Na prática isso significa **"todos os direitos reservados"**: o código era visível, porém ninguém podia reusar, forkar com segurança ou contribuir — o padrão legal na ausência de licença é o mais restritivo possível, não o mais aberto.

Isso ficou evidente ao escrever o post de divulgação, que enfatiza o projeto ser open source. Sem o arquivo, era uma promessa que o repositório não cumpria.

## O que muda

- **`LICENSE`** — MIT, `Copyright (c) 2021-2026 Adams Alves`. O período cobre de `18b4de3` (commit raiz, 03/03/2021) até hoje. O texto foi conferido contra a referência do [SPDX](https://github.com/spdx/license-list-data/blob/main/text/MIT.txt) e é idêntico, fora a linha de copyright.
- **`package.json`** — campos `license`, `author`, `homepage`, `repository` e `bugs`. O `repository` é o que ferramentas de descoberta usam para associar o pacote ao repositório e, por consequência, à licença declarada. O `author` vai sem e-mail, de propósito.
- **`README.md`** — seção *Licença*, deixando explícito que ela cobre o **código**. O conteúdo dos grupos de pedal vem de contribuições da comunidade e do CMS, e não faz parte deste repositório — sem essa ressalva, dá para ler que os dados também estão licenciados sob MIT.
- **`CONTRIBUTING.md`** — o guia descrevia o fluxo como `feature/*`, mas as branches seguem o tipo do Conventional Commit (`feat/`, `fix/`, `docs/`, `chore/`). Corrigido para a prática real. *(Commit separado — `b86a36f` — caso prefira tirar do escopo deste PR.)*

## Por que MIT

É o default para projeto web desse porte: permissiva, curta, reconhecida sem esforço, e não impõe nada a quem reusa. Uma copyleft (GPL) traria obrigações para terceiros que não fazem sentido num mapa colaborativo de bairro.

## Por que `docs:` e não `chore:`

No `release-please-config.json`, `chore` é `hidden: true` e não aparece no changelog. Com `docs:`, a licença entra na seção **📝 Documentação** e é anunciada no próximo release — que parece o tratamento certo para uma mudança que altera o que terceiros podem fazer com o código.

## Verificação

- [x] Texto do `LICENSE` idêntico à referência do SPDX (conferido por diff normalizado, ignorando a linha de copyright)
- [x] `package.json` continua JSON válido
- [x] `yarn lint` limpo; `nuxt typecheck` passou no pre-push
- [x] Hooks de pre-commit passaram (lint-staged + prettier)

## Observações

**O badge de licença do GitHub não aparece com o merge deste PR.** O GitHub detecta a licença a partir da **branch default** (`main`), então o badge — e o campo `licenseInfo` da API, hoje `null` — só mudam depois do `develop` → `main`.

**Os workflows de CI e commitlint não rodaram neste PR.** No SHA do head só existem os três check-runs da Netlify. Ambos disparam em `pull_request` para `develop` e rodaram normalmente no PR do Dependabot em 05/08. Para um PR de texto e metadados o risco é nulo, mas vale investigar a aba Actions antes do próximo PR de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)