### PR TITLE
release: js-yaml 4.3.1 e disparo do release v1.4.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4942,9 +4942,9 @@ js-tokens@^9.0.1:
   integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
 
 js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
PR de release. Leva uma correção de segurança para produção e, principalmente, **produz o push na `main` que dispara o `release-please`** — o do PR #118 se perdeu no incidente do GitHub Actions.

## O que vai

| Commit | O quê |
|---|---|
| `fd0e59b` | `chore(deps):` `js-yaml` 4.3.0 → 4.3.1 (#119) |

Fecha o `GHSA-5p4m-2wfm-xmqj` (**HIGH**, escopo development): complexidade quadrática na detecção de chave duplicada em `!!omap`, explorável como DoS por entrada YAML maliciosa. Diff de 3 linhas no `yarn.lock`.

Com isto, o repositório fica com **0 alertas do Dependabot abertos** — eram 9 no início da tarde.

## Por que este PR importa mais do que o diff sugere

O #118 foi mergeado na `main` às 20:23 (commit `5529e24`), mas o **GitHub Actions estava em outage crítico** ([incidente `qcvjkzcs7j74`](https://www.githubstatus.com), aberto 15:22 UTC). O `PushEvent` na `main` foi registrado, porém nenhum workflow run foi criado — e o Actions não reprocessa pushes perdidos.

Resultado: a **v1.4.1 não foi cortada**. O `release-please` só roda em `push` para a `main`, então é preciso um novo push. Este PR é ele.

Quando o merge acontecer com o Actions de pé, o `release-please` vai calcular a versão a partir de tudo que houve desde a tag `v1.4.0` — incluindo o `fix(deps)` do #117 — e abrir a Release PR da **v1.4.1** com o CHANGELOG contendo 🐛 Correções e 📝 Documentação.

⚠️ **Não mergeie enquanto o Actions não estiver operacional**, ou este push também se perde e o release continua parado.

## Verificação

Rodada **localmente** na branch do #119, já que o CI não está disparando: `lint` limpo, **170 testes passando**, build de produção completo, `js-yaml 4.3.1` confirmado em runtime.

## Nota de fluxo

Mergear com **merge commit** (não squash): o `release-please` lê os Conventional Commits individuais, e o squash colapsaria o `fix(deps)` do #117 que já está na `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)